### PR TITLE
chore: Add Nix build file and update the timing configuration

### DIFF
--- a/build_with_nix.sh
+++ b/build_with_nix.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+SIM=${1:-"qemu"}
+BUILD_TYPE=${2:-"release"}
+
+FLEXUS_ROOT=$(realpath flexus)
+QEMU_ROOT=$(realpath qemu)
+
+case $SIM in
+    *kraken)
+        pushd $FLEXUS_ROOT
+
+        # if build directory exists, remove it
+
+        if [ -d "build" ]; then
+            rm -rf build
+        fi
+        
+        mkdir build
+        cd build
+
+        if [ $BUILD_TYPE = "debug" ];
+        then
+            cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DSIMULATOR=$SIM -G Ninja ..
+        else
+            cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -DSIMULATOR=$SIM -G Ninja ..
+        fi
+
+        ninja
+        popd
+        ;;
+    [cC][Qq]|qemu)
+        pushd $QEMU_ROOT
+
+        if [ "$BUILD_TYPE" = "debug" ]; then
+            ./configure --target-list=aarch64-softmmu       \
+                        --disable-docs                      \
+                        --enable-capstone                   \
+                        --enable-slirp                      \
+                        --enable-snapvm-external            \
+                        --enable-libqflex                   \
+                        --enable-debug                      \
+                        --extra-cflags="-fsanitize=address" \
+                        --extra-cflags="-fno-omit-frame-pointer"
+
+        else
+            ./configure --target-list=aarch64-softmmu       \
+                        --disable-docs                      \
+                        --enable-capstone                   \
+                        --enable-slirp                      \
+                        --enable-snapvm-external            \
+                        --enable-libqflex
+
+        fi
+        popd
+        ninja -C qemu/build
+        ;;
+    [Qq])
+        ninja -C qemu/build
+        ;;
+    *)
+        echo "Never heard of '${SIM}'"
+        exit 1
+        ;;
+esac

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "A flake for building QEMU";
+
+  # Each time this url is changed, please rerun `nix flake lock --update-input nixpkgs` to update the lock file
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: 
+  let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in 
+  {
+
+    devShells.${system}.default = pkgs.llvmPackages_19.stdenv.mkDerivation {
+      pname = "QFlex";
+      version = "1";
+      src = ".";
+
+      buildInputs = [
+        pkgs.ninja
+
+        pkgs.glib
+        pkgs.pkg-config
+        pkgs.pixman
+        pkgs.capstone
+        pkgs.libslirp
+        pkgs.libgcrypt
+        pkgs.zstd
+
+        pkgs.python3
+        pkgs.git
+	      pkgs.pbzip2
+
+        pkgs.flex
+        pkgs.bison
+
+        pkgs.cmake
+        pkgs.boost
+      ];
+
+      # This property is not required by mkDerivation, but appears as a environmental variable.
+      # They can be used directly in the develop shell. 
+    };
+  };
+}


### PR DESCRIPTION
This PR adds Nix building script that uses clang to build both QEMU and the Flexus. Further fixes are required to stop building errors on these branches respectively.

This PR also updates the timing.cfg to set the parameter for the TLB set and associativity. 