### PR TITLE
Feature/enable warmup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN apt install -y --no-install-recommends zstd
 RUN apt install -y --no-install-recommends vim
 RUN apt install -y --no-install-recommends tmux
 RUN apt install -y --no-install-recommends htop
+RUN apt install -y --no-install-recommends telnet
+RUN apt install -y --no-install-recommends expect
 
 # --break-system-package for ubuntu 24.04
 RUN pip install conan && pip cache purge
@@ -72,7 +74,7 @@ RUN --mount=type=bind,source=./qemu,target=/home/dev/qflex/qemu,rw conan profile
     conan cache clean -v && \
     conan remove -c "*" && \
     ./build cq ${MODE} && \
-    python3 build-multiple-kraken_vanilla.py \
+    python3 build-multiple-kraken_vanilla.py --core-count 8 --memory-controller 1 \
     mkdir /home/dev/qflex/kraken_out && \
     cp -r out/lib/Release /home/dev/qflex/kraken_out && \
     rm -rf out && \

--- a/build-multiple-kraken_vanilla.py
+++ b/build-multiple-kraken_vanilla.py
@@ -1,9 +1,22 @@
 #!/usr/bin/env python3
 
 import os
+import argparse
 
-CORE_COUNT = [8]
-MEMORY_CONTROLLER = [1]
+# CORE_COUNT = [1, 4, 16, 64]
+# MEMORY_CONTROLLER = [1, 1, 2, 8]
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description='Build Kraken targets with specified configuration.')
+parser.add_argument('--core-count', type=int, required=True,
+                    help='Number of cores')
+parser.add_argument('--memory-controller', type=int, required=True,
+                    help='Number of memory controllers')
+
+args = parser.parse_args()
+
+core_count = args.core_count
+mem_count = args.memory_controller
 
 TARGETS = [
     "knottykraken",
@@ -11,25 +24,22 @@ TARGETS = [
 ]
 
 
-for (core_count, mem_count) in zip(CORE_COUNT, MEMORY_CONTROLLER):
-    for target in TARGETS:
-        # first, update the configuration.
-        with open(f"flexus/target/{target}/wiring.cpp", "r") as f:
-            config = f.readlines()
+for target in TARGETS:
+    # first, update the configuration.
+    with open(f"flexus/target/{target}/wiring.cpp", "r") as f:
+        config = f.readlines()
 
-        for i in range(len(config)):
-            if "FLEXUS_INSTANTIATE_COMPONENT_ARRAY( MemoryLoopback, theMemoryCfg, theMemory, FIXED, DIVIDE," in config[i]:
-                config[i] = f"FLEXUS_INSTANTIATE_COMPONENT_ARRAY( MemoryLoopback, theMemoryCfg, theMemory, FIXED, DIVIDE, {mem_count} );\n"
+    for i in range(len(config)):
+        if "FLEXUS_INSTANTIATE_COMPONENT_ARRAY( MemoryLoopback, theMemoryCfg, theMemory, FIXED, DIVIDE," in config[i]:
+            config[i] = f"FLEXUS_INSTANTIATE_COMPONENT_ARRAY( MemoryLoopback, theMemoryCfg, theMemory, FIXED, DIVIDE, {mem_count} );\n"
 
-        with open(f"flexus/target/{target}/wiring.cpp", "w") as f:
-            f.write("".join(config))
-        
-        # then, execute the build command
-        assert os.system(f"./build {target}") == 0
-
-        # finally, move the build output to a specific directory.
-        os.system(f"rm -rf flexus/build-{target}-{core_count}c")
-        # os.system(f"mv flexus/build-{target} flexus/build-{target}-{core_count}c")
-
+    with open(f"flexus/target/{target}/wiring.cpp", "w") as f:
+        f.write("".join(config))
     
+    # then, execute the build command
+    assert os.system(f"./build {target}") == 0
+
+    # finally, move the build output to a specific directory.
+    os.system(f"rm -rf flexus/build-{target}-{core_count}c")
+    # os.system(f"mv flexus/build-{target} flexus/build-{target}-{core_count}c")
         

--- a/commands/config.py
+++ b/commands/config.py
@@ -239,18 +239,18 @@ class ExperimentContext(BaseModel):
         if not os.path.exists(f"{self.get_experiment_folder_address()}/lib/WormCacheQFlex"):
             os.system(f"cp -r ./WormCacheQFlex {self.get_experiment_folder_address()}/lib/WormCacheQFlex")
 
-        # Move files to lib
+        # Create & Move files to lib
         lib_files = [
             "libknottykraken.so", 
             "libsemikraken.so"
         ]
         for f in lib_files:
-            if not os.path.exists(f"/home/dev/qflex/kraken_out/{f}"):
-                raise FileNotFoundError(f"Error: {f} not found in ./home/dev/qflex/kraken_out/")
             if not os.path.exists(f"{self.get_experiment_folder_address()}/lib/{f}"):
-                os.system(f"cp /home/dev/qflex/kraken_out/{f} {self.get_experiment_folder_address()}/lib/{f}")
-
-        
+                os.system(f"python3 ./build-multiple-kraken_vanilla.py --core-count {self.simulation_context.core_count} --memory-controller {self.simulation_context.mem_controller_count}")
+                print(f"Created Kraken libraries")
+                if not os.path.exists(f"/home/dev/qflex/out/lib/Release/{f}"):
+                    raise FileNotFoundError(f"Error: {f} not found in /home/dev/qflex/out/lib/Release/")
+                os.system(f"cp /home/dev/qflex/out/lib/Release/{f} {self.get_experiment_folder_address()}/lib/{f}")        
 
 
 

--- a/commands/jinja_loaders/__init__.py
+++ b/commands/jinja_loaders/__init__.py
@@ -3,11 +3,13 @@ from .flexus_checkpoint_cfg_loader import FlexusCheckpointConfigLoader
 from .timing_cfg_loader import TimingLoader
 from .wormloader import WormConfigLoader
 from .flexus_script_loader import FlexusScriptLoader
+from .load_expect_loader import LoadExpectLoader
 
 __all__ = [
     "ParameterLoader",
     "FlexusCheckpointConfigLoader",
     "TimingLoader",
     "WormConfigLoader",
-    "FlexusScriptLoader"
+    "FlexusScriptLoader",
+    "LoadExpectLoader"
 ]

--- a/commands/jinja_loaders/flexus_script_loader.py
+++ b/commands/jinja_loaders/flexus_script_loader.py
@@ -26,4 +26,5 @@ class FlexusScriptLoader(ParameterLoader):
             "DOUBLED_VCPU": self.experiment_context.simulation_context.doubled_vcpu,
             "MEMORY": self.experiment_context.simulation_context.memory_gb * 1024,  # in MB
             "QEMU_NIC": self.experiment_context.simulation_context.qemu_nic.strip().lower(),
+            "QEMU_IMAGE_NAME": self.experiment_context.image_name,
         }

--- a/commands/jinja_loaders/load_expect_loader.py
+++ b/commands/jinja_loaders/load_expect_loader.py
@@ -1,0 +1,36 @@
+import os
+from .parameterloader import ParameterLoader
+from ..config import ExperimentContext
+
+
+class LoadExpectLoader(ParameterLoader):
+    def __init__(self,
+                 experiment_context: ExperimentContext,
+                 trigger_phrase: str = "WARMUP COMPLETED",
+                 monitor_port: int = 55555,
+                 spawn_command: str = "",
+                 save_vm_name: str = "vm-snapshot"):
+        super().__init__(
+            experiment_context=experiment_context,
+            parameter_template='load.expect.j2',
+            output_name='load.expect',
+            out_folder='run'
+        )
+        self.trigger_phrase = trigger_phrase
+        self.monitor_port = monitor_port
+        self.spawn_command = spawn_command
+        self.save_vm_name = save_vm_name
+    
+    def load_parameters(self) -> str:
+        result = super().load_parameters()
+        # Make the script executable
+        os.system(f"chmod +x {result}")
+        return result
+
+    def get_context(self):
+        return {
+            "TRIGGER_PHASE": self.trigger_phrase,
+            "MONITOR_PORT": self.monitor_port,
+            "SPAWN_COMMAND": self.spawn_command,
+            "SAVE_VM_NAME": self.save_vm_name,
+        }

--- a/commands/load.py
+++ b/commands/load.py
@@ -1,25 +1,61 @@
 from commands import Executor
 from .config import ExperimentContext
-from commands.qemu import QemuCommonArgParser   
+from commands.qemu import QemuCommonArgParser
+from .jinja_loaders import LoadExpectLoader   
 
 
 class Load(Executor):
 
     def __init__(self,
-                 experiment_context: ExperimentContext,):
+                 experiment_context: ExperimentContext,
+                 warmup_magic_phrase: str = "",
+                 post_warmup_savevm_name: str = "load"):
         self.experiment_context = experiment_context
+        self.warmup_magic_phrase = warmup_magic_phrase
+        self.post_warmup_savevm_name = post_warmup_savevm_name
         self.qemu_common_parser = QemuCommonArgParser(experiment_context)
 
+        # Generate load.expect script for automated savevm when magic phrase appears
+        if self.warmup_magic_phrase != "":
+
+            spawn_command = f""" ./qemu-system-aarch64 \
+            {self.qemu_common_parser.get_qemu_base_args()} \
+            {self.qemu_common_parser.get_qemu_telnet_args()} \
+            {self.qemu_common_parser.quantum_args()}
+            """
+
+            self.load_expect_loader = LoadExpectLoader(
+                experiment_context=experiment_context,
+                trigger_phrase=self.warmup_magic_phrase,
+                monitor_port=self.qemu_common_parser.monitor_port,
+                spawn_command=spawn_command,
+                save_vm_name=self.post_warmup_savevm_name
+            )
+            self.load_expect_script = self.load_expect_loader.load_parameters()
+
+
+
+
     def cmd(self) -> str:
+
+        if self.warmup_magic_phrase == "":
+
+            load_cmd = f"""
+            ./qemu-system-aarch64 \
+            {self.qemu_common_parser.get_qemu_base_args()} \
+            {self.qemu_common_parser.quantum_args()}
+            """
         
-        load_cmd = f"""
-        ./qemu-system-aarch64 \
-        {self.qemu_common_parser.get_qemu_base_args()} \
-        {self.qemu_common_parser.quantum_args()}
-        """
-    
-        # WormCacheQFlex/src/parameter.rss
-        return [
-            f"cd {self.experiment_context.get_experiment_folder_address()}/run", 
-            load_cmd
-        ]
+            # WormCacheQFlex/src/parameter.rss
+            return [
+                f"cd {self.experiment_context.get_experiment_folder_address()}/run", 
+                load_cmd
+            ]
+
+        else:
+            # Use the generated expect script for automated savevm
+            return [
+                f"cd {self.experiment_context.get_experiment_folder_address()}/run",
+                f"expect {self.load_expect_script}"
+            ]
+            

--- a/commands/partition.py
+++ b/commands/partition.py
@@ -38,7 +38,7 @@ class PartitionCommand(Executor):
             raise FileExistsError("Partitions already exist.")
         return [
             f"cd {self.experiment_folder}",
-            f"{self.experiment_folder}/partition.py {self.partition_count}",
+            f"{self.experiment_folder}/partition.py --partition-count {self.partition_count} --image-name {self.experiment_context.image_name}",
         ]
 
 

--- a/commands/qemu.py
+++ b/commands/qemu.py
@@ -12,9 +12,9 @@ class QemuCommonArgParser:
         self.core_coeff = 1
         if self.double_cores:
             self.core_coeff = 2
+        self.monitor_port = 55555
+        
 
-        
-        
         self.nic_command = self.experiment_context.simulation_context.qemu_nic.strip().lower()
 
         self.loadvm = ''
@@ -63,8 +63,16 @@ class QemuCommonArgParser:
         print("="*50+"Quantum command arguments:"+"="*50)
         print(self.quantum_command)
         return self.quantum_command
- 
 
+    def get_qemu_telnet_args(self) -> str:
+
+        qemu_monitor_args = f""" -chardev stdio,id=char_stdio,mux=on,signal=off \
+        -mon chardev=char_stdio,mode=readline \
+        -serial chardev:char_stdio \
+        -monitor telnet:127.0.0.1:{self.monitor_port},server,nowait"""
+        print("="*50+"QEMU monitor - telnet arguments:"+"="*50)
+        print(qemu_monitor_args)
+        return qemu_monitor_args
     
 
 

--- a/partition.py
+++ b/partition.py
@@ -91,6 +91,7 @@ NECESSARY_BINARY_FILES = [
     "../cfg/timing.cfg",
     "../bin/checkpoint_conversion",
     mem_folder_name,
+    "efi-virtio.rom"
 ]
 
 for p in range(PARTITION_COUNT):

--- a/partition.py
+++ b/partition.py
@@ -4,6 +4,7 @@ import os
 import sys
 import math
 import glob
+import argparse
 
 '''
 How this program works:
@@ -15,8 +16,17 @@ How this program works:
 6. Copy the starting_script to each partition folder.
 '''
 
-# By default the partition is equal to the number of CPU cores.
-if len(sys.argv) != 2:
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description='Partition snapshot files for parallel execution.')
+parser.add_argument('--partition-count', type=int, nargs='?', default=None,
+                    help='Number of partitions (default: CPU core count)')
+parser.add_argument('--image-name', type=str, default='root.qcow2',
+                    help='QEMU image filename (default: root.qcow2)')
+
+args = parser.parse_args()
+
+# Set partition count
+if args.partition_count is None:
     print("Default PARTITION_COUNT is the number of CPU cores.")
     cpu_count = os.cpu_count()
     if cpu_count is None:
@@ -24,8 +34,12 @@ if len(sys.argv) != 2:
         sys.exit(1)
     PARTITION_COUNT: int = cpu_count
 else:
-    PARTITION_COUNT = int(sys.argv[1])
+    PARTITION_COUNT = args.partition_count
     print(f"Setting partition count to {PARTITION_COUNT}")
+
+QEMU_IMAGE_NAME = args.image_name
+if QEMU_IMAGE_NAME != 'root.qcow2':
+    print(f"Using QEMU image: {QEMU_IMAGE_NAME}")
 
 
 os.chdir("./run")
@@ -71,7 +85,7 @@ mem_folder_name = mem_folder_name[0]
 # Create symbolic links for the necessary bindary files in the current folder.
 NECESSARY_BINARY_FILES = [
     "QEMU_EFI.fd",
-    "root.qcow2",
+    QEMU_IMAGE_NAME,
     "debug.cfg",
     "../cfg/flexus_configuration.json",
     "../cfg/timing.cfg",

--- a/qflex
+++ b/qflex
@@ -63,6 +63,12 @@ def boot(
 @data_class_wrap(ExperimentContextTyper("experiment_context"))
 def load(
     experiment_context: ExperimentContext,
+    warmup_magic_phrase: Annotated[str, typer.Option(
+        help="A magic phrase to indicate that workload warmup is completed."
+    )]="",
+    post_warmup_savevm_name: Annotated[str, typer.Option(
+        help="Name of the savevm snapshot to create after warmup."
+    )]="load",
 ):
     """
     Load a QEMU virtual machine from a snapshot with specified parameters.
@@ -70,7 +76,9 @@ def load(
     This is the third step, to prepare for functional warming.
     """
     load_executor = Load(
-        experiment_context=experiment_context
+        experiment_context=experiment_context,
+        warmup_magic_phrase=warmup_magic_phrase,
+        post_warmup_savevm_name=post_warmup_savevm_name,
     )
     load_executor.execute(to_stdio=True, run_in_background=False)
 

--- a/templates/load.expect.j2
+++ b/templates/load.expect.j2
@@ -1,0 +1,61 @@
+#!/usr/bin/expect -f
+
+# ---------- config ----------
+set timeout -1
+set trigger_phrase "{{ TRIGGER_PHASE }}"
+set monitor_host "127.0.0.1"
+set monitor_port {{ MONITOR_PORT }}
+# ----------------------------
+
+# Absolutely no output from expect itself
+log_user 0
+
+# Save terminal state
+set saved_tty [stty -g]
+
+proc restore_tty {} {
+    global saved_tty
+    catch {stty $saved_tty}
+}
+
+# Wrap exit to always restore terminal
+rename exit __orig_exit
+proc exit {% raw %}{{status 0}}{% endraw %} {
+    restore_tty
+    __orig_exit $status
+}
+
+# Always restore terminal on SIGINT and SIGTERM 
+# (When it occurs outside QEMU but inside expect)
+trap {exit 130} SIGINT
+trap {exit 143} SIGTERM
+
+# Enter raw mode
+stty raw -echo
+
+# Start QEMU directly
+spawn {{ SPAWN_COMMAND }}
+
+# Hand over full control to the user,
+# but observe output for the trigger phrase
+interact -o -nobuffer -re $trigger_phrase {
+
+    # Talk to monitor via telnet
+    spawn telnet $monitor_host $monitor_port
+    set timeout 5
+    expect {
+        -re "Connected|Escape character" {}
+        timeout { 
+            exit 1 
+        }
+    }
+
+    # Save VM and Quit
+    send "savevm {{ SAVE_VM_NAME }}\r"
+    expect -re "(qemu)"
+    send "quit\r"
+    expect eof
+    send_user "\nVM snapshot '{{ SAVE_VM_NAME }}' saved successfully\n\n"
+
+    exit 0
+} 

--- a/templates/parameter.rs.j2
+++ b/templates/parameter.rs.j2
@@ -72,7 +72,7 @@ pub const USE_HIGHLY_ASSOCIATIVE_L1TLB: bool = false;
 
 // ITLB
 
-pub const ITLB_ASSO: usize = 64;
+pub const ITLB_ASSO: usize = 48;
 
 pub const ITLB_SET: usize = 1;
 static_assertions::const_assert!(!(ITLB_SET != 1 && USE_HIGHLY_ASSOCIATIVE_L1TLB));
@@ -80,7 +80,7 @@ static_assertions::const_assert!(ITLB_SET.is_power_of_two());
 
 // DTLB
 
-pub const DTLB_ASSO: usize = 64;
+pub const DTLB_ASSO: usize = 48;
 
 pub const DTLB_SET: usize = 1;
 static_assertions::const_assert!(!(DTLB_SET != 1 && USE_HIGHLY_ASSOCIATIVE_L1TLB));

--- a/templates/run_flexus.sh.j2
+++ b/templates/run_flexus.sh.j2
@@ -41,7 +41,7 @@ do
         -m {{ MEMORY }} \
         -boot menu=on \
         -bios ./QEMU_EFI.fd \
-        -drive if=virtio,file=root.qcow2,format=qcow2,snapshot=on,tmp-snapshot-name=snapshot_$idx \
+        -drive if=virtio,file={{ QEMU_IMAGE_NAME }},format=qcow2,snapshot=on,tmp-snapshot-name=snapshot_$idx \
         {{ QEMU_NIC }} \
         -rtc clock=vm \
         -loadvm snapshot_$idx,on-demand \


### PR DESCRIPTION
Added following:

1) Removed hard-coded qemu-image-name (root.qcow2)
2) Modified partition.py to copy efi-virtio.rom to the partition folders
3) Automated libknottykraken.so and libsemikraken.so file creation depending on core_count and memory_controller configurations
4) Added feature to stop warmup execution during load phase using magic phrase and generate the snapshot

This PR addresses #67 