### PR TITLE
Allow clean QEMU exit before disk conversion

### DIFF
--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -142,6 +142,15 @@ def convert_single(
                 f"(exit code {qemu_proc.returncode}).{_tail_file(qemu_log)}"
             )
 
+    def _ensure_qemu_not_failed(phase: str) -> None:
+        if qemu_proc is None:
+            return
+        if qemu_proc.poll() not in (None, 0):
+            raise RuntimeError(
+                f"[{snapshot}] qemu failed before {phase} "
+                f"(exit code {qemu_proc.returncode}).{_tail_file(qemu_log)}"
+            )
+
     def _terminate_qemu() -> None:
         if qemu_proc is None:
             return
@@ -284,7 +293,7 @@ def convert_single(
 
         print(f"[{snapshot}] converting disk image")
         _check_cancelled()
-        _ensure_qemu_running("disk image conversion")
+        _ensure_qemu_not_failed("disk image conversion")
         convert_sh = _refresh_qpoints_helper(
             qpoints_root,
             run_dir,


### PR DESCRIPTION
## Summary
- allow `qflex qpoints convert-single` to proceed when QEMU has already exited cleanly before disk image conversion
- keep failing when QEMU exits with a nonzero status before the conversion phase
- preserve the existing error context by tailing the QEMU log on real failures

## Validation
- `./qflex qpoints convert-single --qflex-ckp-dir /mnt/sdb/aansari/experiments/single-core --gem5-ckp-dir /mnt/sdb/aansari/checkpoints/single-core --core-count 1 --memory-gb 16 --base single-core.qcow2 --snapshot snapshot_0 --overwrite`
- `./qflex qpoints run-gem5 --gem5-ckp-dir /mnt/sdb/aansari/checkpoints/single-core --experiment test --snapshot snapshot_0 --inst 10000 --core-count 1 --timing-ruby`

## Notes
- this does not yet harden the conversion flow against canonical qcow2 mutation; that follow-up remains tracked locally
- the Ruby timing smoke test completed successfully after the converted checkpoint was regenerated