### PR TITLE
Align qflex CLI with merged tracing and validation flows

### DIFF
--- a/commands/config.py
+++ b/commands/config.py
@@ -252,11 +252,13 @@ class ExperimentContext(BaseModel):
             "libknottykraken.so", 
             "libsemikraken.so"
         ]
+        kraken_out_dir = os.path.join(repo_root, "kraken_out")
         for f in lib_files:
-            if not os.path.exists(f"/home/dev/qflex/kraken_out/{f}"):
-                raise FileNotFoundError(f"Error: {f} not found in ./home/dev/qflex/kraken_out/")
+            kraken_lib = os.path.join(kraken_out_dir, f)
+            if not os.path.exists(kraken_lib):
+                raise FileNotFoundError(f"Error: {f} not found in {kraken_out_dir}/")
             if not os.path.exists(f"{self.get_experiment_folder_address()}/lib/{f}"):
-                os.system(f"cp /home/dev/qflex/kraken_out/{f} {self.get_experiment_folder_address()}/lib/{f}")
+                shutil.copy2(kraken_lib, f"{self.get_experiment_folder_address()}/lib/{f}")
 
         
 

--- a/commands/qemu.py
+++ b/commands/qemu.py
@@ -52,7 +52,7 @@ class QemuCommonArgParser:
         {self.nic_command} \
         -rtc clock=vm \
         {self.loadvm} \
-        {'-monitor telnet::%d,server,nowait' % monitor_port if monitor_port is not None else ''} \
+        {'-monitor telnet:127.0.0.1:%d,server,nowait' % monitor_port if monitor_port is not None else ''} \
         {self.cd_rom} \
         -nographic -no-reboot"""
         print("="*50+"QEMU command arguments:"+"="*50)

--- a/commands/qemu.py
+++ b/commands/qemu.py
@@ -20,14 +20,12 @@ class QemuCommonArgParser:
         self.loadvm = ''
         if self.experiment_context.loadvm_name is not None and len(self.experiment_context.loadvm_name) > 0:
             self.loadvm = f'-loadvm {self.experiment_context.loadvm_name}'
-    
+
         check_period_quantum_coeff = self.simulation_context.check_period_quantum_coeff
-        self.quantum_command = ''
-        # TODO check why 53 : checked this is a check done to see whether or not we need to do checkpointing, with the assumption being it will usually be way less than the sampling interval
-        if self.simulation_context.is_parallel:
-            self.quantum_command = f'   -quantum size={self.simulation_context.quantum_size},check_period={int(self.simulation_context.quantum_size * check_period_quantum_coeff)} '
-        else:
-            self.quantum_command = f'   -icount shift=0,align=off,sleep=off,q={self.simulation_context.quantum_size},check_period={int(self.simulation_context.quantum_size * check_period_quantum_coeff)} '
+        self.quantum_size = self.simulation_context.quantum_size
+        self.check_period = int(
+            self.simulation_context.quantum_size * check_period_quantum_coeff
+        )
 
         self.cd_rom = ''
         self.use_cd_rom = self.simulation_context.use_cd_rom
@@ -42,17 +40,19 @@ class QemuCommonArgParser:
 
 
         
-    def get_qemu_base_args(self) -> str:
+    def get_qemu_base_args(self, monitor_port: int | None = None) -> str:
+        drive_arg = f"-drive if=virtio,file={self.image_address},format=qcow2"
 
         qemu_args = f""" -M virt,gic-version=max,virtualization=off,secure=off \
         -smp {self.core_coeff * self.cores} \
         -cpu max,pauth=off -m {self.memory_size_mb} \
         -boot order=d,menu=on \
         -bios ./QEMU_EFI.fd \
-        -drive if=virtio,file={self.image_address},format=qcow2 \
+        {drive_arg} \
         {self.nic_command} \
         -rtc clock=vm \
         {self.loadvm} \
+        {'-monitor telnet::%d,server,nowait' % monitor_port if monitor_port is not None else ''} \
         {self.cd_rom} \
         -nographic -no-reboot"""
         print("="*50+"QEMU command arguments:"+"="*50)
@@ -60,15 +60,20 @@ class QemuCommonArgParser:
         return qemu_args
 
     def quantum_args(self) -> str:
+        quantum_command = ''
+        # TODO check why 53 : checked this is a check done to see whether or not we need to do checkpointing, with the assumption being it will usually be way less than the sampling interval
+        if self.simulation_context.is_parallel:
+            quantum_command = (
+                f'   -quantum size={self.quantum_size},check_period={self.check_period} '
+            )
+        else:
+            quantum_command = (
+                f'   -icount shift=0,align=off,sleep=off,q={self.quantum_size},'
+                f'check_period={self.check_period} '
+            )
         print("="*50+"Quantum command arguments:"+"="*50)
-        print(self.quantum_command)
-        return self.quantum_command
+        print(quantum_command)
+        return quantum_command
  
 
     
-
-
-
-
-
-

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -416,7 +416,9 @@ def run_gem5(
     core_count: int,
     branch_trace: bool = False,
     data_trace: bool = False,
+    dump_cache_state: bool = False,
     timing_ruby: bool = False,
+    sim_config: Optional[str] = None,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     qpoints_root = repo_root / "QPoints"
@@ -440,8 +442,12 @@ def run_gem5(
         args.append("--branch-trace")
     if data_trace:
         args.append("--data-trace")
+    if dump_cache_state:
+        args.append("--dump-cache-state")
     if timing_ruby:
         args.append("--timing-ruby")
+    if sim_config:
+        args.extend(["--sim-config", sim_config])
     subprocess.run(
         args,
         cwd=str(qpoints_root),

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -420,6 +420,9 @@ def run_gem5(
     timing_ruby: bool = False,
     sim_config: Optional[str] = None,
 ) -> None:
+    if dump_cache_state and not timing_ruby:
+        raise RuntimeError("--dump-cache-state requires --timing-ruby.")
+
     repo_root = Path(__file__).resolve().parents[1]
     qpoints_root = repo_root / "QPoints"
     _prepare_qpoints_root(qpoints_root, ("run_gem5.sh",))

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -415,6 +415,7 @@ def run_gem5(
     inst: int,
     core_count: int,
     branch_trace: bool = False,
+    data_trace: bool = False,
     timing_ruby: bool = False,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[1]
@@ -437,6 +438,8 @@ def run_gem5(
     ]
     if branch_trace:
         args.append("--branch-trace")
+    if data_trace:
+        args.append("--data-trace")
     if timing_ruby:
         args.append("--timing-ruby")
     subprocess.run(

--- a/commands/test_worm.py
+++ b/commands/test_worm.py
@@ -12,11 +12,13 @@ class TestWorm(Executor):
     def __init__(self,
                  experiment_context: ExperimentContext,
                  skip_generate_cfg: bool = False,
-                 branch_trace: bool = False):
+                 branch_trace: bool = False,
+                 monitor_port: int | None = None):
         self.experiment_context = experiment_context
         self.simulation_context = self.experiment_context.simulation_context
         self.qemu_common_parser = QemuCommonArgParser(experiment_context)
         self.branch_trace = branch_trace
+        self.monitor_port = monitor_port
 
         experiment_folder = self.experiment_context.get_experiment_folder_address()
         self.worm_params_address = f"{experiment_folder}/cfg/parameter.rs"
@@ -61,7 +63,7 @@ class TestWorm(Executor):
             branch_trace_opt = ",branch_trace=1"
         test_cmd = f"""
         ./qemu-system-aarch64 \
-        {self.qemu_common_parser.get_qemu_base_args()} \
+        {self.qemu_common_parser.get_qemu_base_args(monitor_port=self.monitor_port)} \
         {self.qemu_common_parser.quantum_args()} \
         -plugin ../lib/libworm_cache.so,mode=normal{branch_trace_opt}
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+markers =
+    unit: fast unit-level tests
+    integration: tests that execute real flows and artifacts
+    requires_testenv: tests that need a configured local test environment
+    slow: tests with materially higher runtime

--- a/qflex
+++ b/qflex
@@ -286,9 +286,16 @@ def qpoints_run_gem5_cmd(
     core_count: Annotated[int, typer.Option(help="Number of CPU cores.")],
     branch_trace: Annotated[bool, typer.Option(help="Enable branch trace logging.")] = False,
     data_trace: Annotated[bool, typer.Option(help="Enable data access trace logging.")] = False,
+    dump_cache_state: Annotated[
+        bool, typer.Option(help="Enable Ruby cache-state dumping (requires --timing-ruby).")
+    ] = False,
     timing_ruby: Annotated[
         bool, typer.Option(help="Run gem5 in O3 Ruby MESI_Two_Level mode.")
     ] = False,
+    sim_config: Annotated[
+        str | None,
+        typer.Option(help="Optional QPoints/gem5 config args file to pass through to run_gem5.sh."),
+    ] = None,
 ):
     """
     Run gem5 for a single snapshot using QPoints run_gem5.sh.
@@ -301,7 +308,9 @@ def qpoints_run_gem5_cmd(
         core_count=core_count,
         branch_trace=branch_trace,
         data_trace=data_trace,
+        dump_cache_state=dump_cache_state,
         timing_ruby=timing_ruby,
+        sim_config=sim_config,
     )
 
 

--- a/qflex
+++ b/qflex
@@ -109,6 +109,9 @@ def test_worm(
     branch_trace: Annotated[bool, typer.Option(
         help="Whether to log branch PCs to per-core files."
     )]=False,
+    monitor_port: Annotated[int, typer.Option(
+        help="Optional QEMU monitor port for graceful stop / debugging."
+    )]=45454,
 ):
     """
     Run a test QEMU session with WormCache in normal mode (no snapshots).
@@ -117,6 +120,7 @@ def test_worm(
         experiment_context=experiment_context,
         skip_generate_cfg=skip_generate_cfg,
         branch_trace=branch_trace,
+        monitor_port=monitor_port,
     )
     test_worm_executor.execute(to_stdio=True, run_in_background=False)
 

--- a/qflex
+++ b/qflex
@@ -285,6 +285,7 @@ def qpoints_run_gem5_cmd(
     inst: Annotated[int, typer.Option(help="Instruction count.")],
     core_count: Annotated[int, typer.Option(help="Number of CPU cores.")],
     branch_trace: Annotated[bool, typer.Option(help="Enable branch trace logging.")] = False,
+    data_trace: Annotated[bool, typer.Option(help="Enable data access trace logging.")] = False,
     timing_ruby: Annotated[
         bool, typer.Option(help="Run gem5 in O3 Ruby MESI_Two_Level mode.")
     ] = False,
@@ -299,6 +300,7 @@ def qpoints_run_gem5_cmd(
         inst=inst,
         core_count=core_count,
         branch_trace=branch_trace,
+        data_trace=data_trace,
         timing_ruby=timing_ruby,
     )
 

--- a/qflex
+++ b/qflex
@@ -109,9 +109,9 @@ def test_worm(
     branch_trace: Annotated[bool, typer.Option(
         help="Whether to log branch PCs to per-core files."
     )]=False,
-    monitor_port: Annotated[int, typer.Option(
+    monitor_port: Annotated[int | None, typer.Option(
         help="Optional QEMU monitor port for graceful stop / debugging."
-    )]=45454,
+    )]=None,
 ):
     """
     Run a test QEMU session with WormCache in normal mode (no snapshots).
@@ -300,6 +300,10 @@ def qpoints_run_gem5_cmd(
     """
     Run gem5 for a single snapshot using QPoints run_gem5.sh.
     """
+    if dump_cache_state and not timing_ruby:
+        raise typer.BadParameter(
+            "--dump-cache-state requires --timing-ruby."
+        )
     qpoints_run_gem5(
         gem5_ckp_dir=gem5_ckp_dir,
         experiment=experiment,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,141 @@
+# qflex Test Guide
+
+This folder contains the outer `qflex` repo test suite.
+
+The outer repo mainly owns:
+
+- the top-level CLI surface
+- argument forwarding into QPoints
+- checkpoint conversion and run-gem5 orchestration
+
+So the tests here focus on the wrapper contract rather than re-testing gem5 internals.
+
+## Files
+
+- [testenv.py](/home/dev/qflex_git/tests/testenv.py)
+  - shared test-environment loader for the outer repo
+  - resolves config from:
+    - `QFLEX_TEST_CONFIG`
+    - repo-local `.testenv.json`
+    - `~/.config/qflex/testenv.json`
+  - provides integration defaults:
+    - snapshot: `snapshot_1`
+    - instructions: `100000`
+  - supports artifact retention control through:
+    - `keep_artifacts` in the testenv file
+    - `QFLEX_TEST_KEEP_ARTIFACTS=1`
+
+- [test_testenv.py](/home/dev/qflex_git/tests/test_testenv.py)
+  - verifies testenv path resolution
+  - verifies required-key checking
+  - verifies default snapshot / instruction settings
+  - verifies artifact retention policy parsing
+
+- [test_qpoints_cli.py](/home/dev/qflex_git/tests/test_qpoints_cli.py)
+  - checks that `qflex qpoints run-gem5 --help` exposes the expected tracing options
+  - verifies that the outer CLI forwards those options into `commands/qpoints.py`
+  - protects the wrapper contract for:
+    - `--branch-trace`
+    - `--data-trace`
+    - `--dump-cache-state`
+    - `--timing-ruby`
+    - `--sim-config`
+
+- [test_qpoints_integration.py](/home/dev/qflex_git/tests/test_qpoints_integration.py)
+  - real integration tests for the outer `qflex` CLI
+  - creates a writable qcow2 copy from the configured base image
+  - converts `snapshot_1`
+  - runs gem5 for `100000` instructions by default
+  - covers:
+    - `qflex qpoints convert-single`
+    - classic Atomic run with branch + data trace
+    - classic Atomic run with `--sim-config`
+    - Ruby O3 run with data trace + cache dump + `--sim-config`
+
+## How to run
+
+Use the shared local venv:
+
+```bash
+/home/dev/qflex/.venv/bin/python -m pytest -q
+```
+
+Run only outer-repo tests:
+
+```bash
+cd /home/dev/qflex_git
+/home/dev/qflex/.venv/bin/python -m pytest -q
+```
+
+Run only integration tests:
+
+```bash
+cd /home/dev/qflex_git
+/home/dev/qflex/.venv/bin/python -m pytest -q -m integration
+```
+
+Run one specific test:
+
+```bash
+cd /home/dev/qflex_git
+/home/dev/qflex/.venv/bin/python -m pytest -q tests/test_qpoints_integration.py::test_qflex_run_gem5_ruby_data_trace_cache_dump_and_sim_config
+```
+
+## Test environment file
+
+Integration tests need a local config file that points to machine-specific assets.
+
+Minimal shape:
+
+```json
+{
+  "qflex_ckp_dir": "/path/to/qflex/checkpoints",
+  "gem5_ckp_dir": "/path/to/gem5/checkpoints",
+  "core_count": 1,
+  "memory_gb": 16,
+  "base": "/path/to/base.qcow2"
+}
+```
+
+Optional fields:
+
+```json
+{
+  "default_snapshot": "snapshot_1",
+  "default_insts": 100000,
+  "ssh_host": "127.0.0.1",
+  "ssh_user": "qflex",
+  "monitor_base": 45454,
+  "qmp_base": 4444,
+  "ssh_base": 2222,
+  "keep_artifacts": false
+}
+```
+
+## Artifact policy
+
+By default, integration tests clean up the artifacts they create:
+
+- writable qcow2 copy used for the test session
+- converted gem5 checkpoint under the configured `gem5_ckp_dir`
+- pytest-generated `QPoints/sim_outs/pytest_*` experiment directories
+
+To keep those artifacts for debugging:
+
+```bash
+export QFLEX_TEST_KEEP_ARTIFACTS=1
+```
+
+or set:
+
+```json
+{
+  "keep_artifacts": true
+}
+```
+
+## Notes
+
+- integration tests intentionally use `snapshot_1` by default so `snapshot_0` remains untouched for active work
+- if no testenv file is configured, integration tests skip themselves cleanly instead of failing
+- these tests validate the outer wrapper behavior, not just whether a local helper function returns the right list of args

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ So the tests here focus on the wrapper contract rather than re-testing gem5 inte
 
 ## Files
 
-- [testenv.py](/home/dev/qflex_git/tests/testenv.py)
+- [testenv.py](testenv.py)
   - shared test-environment loader for the outer repo
   - resolves config from:
     - `QFLEX_TEST_CONFIG`
@@ -25,13 +25,13 @@ So the tests here focus on the wrapper contract rather than re-testing gem5 inte
     - `keep_artifacts` in the testenv file
     - `QFLEX_TEST_KEEP_ARTIFACTS=1`
 
-- [test_testenv.py](/home/dev/qflex_git/tests/test_testenv.py)
+- [test_testenv.py](test_testenv.py)
   - verifies testenv path resolution
   - verifies required-key checking
   - verifies default snapshot / instruction settings
   - verifies artifact retention policy parsing
 
-- [test_qpoints_cli.py](/home/dev/qflex_git/tests/test_qpoints_cli.py)
+- [test_qpoints_cli.py](test_qpoints_cli.py)
   - checks that `qflex qpoints run-gem5 --help` exposes the expected tracing options
   - verifies that the outer CLI forwards those options into `commands/qpoints.py`
   - protects the wrapper contract for:
@@ -41,7 +41,7 @@ So the tests here focus on the wrapper contract rather than re-testing gem5 inte
     - `--timing-ruby`
     - `--sim-config`
 
-- [test_qpoints_integration.py](/home/dev/qflex_git/tests/test_qpoints_integration.py)
+- [test_qpoints_integration.py](test_qpoints_integration.py)
   - real integration tests for the outer `qflex` CLI
   - creates a writable qcow2 copy from the configured base image
   - converts `snapshot_1`
@@ -54,31 +54,31 @@ So the tests here focus on the wrapper contract rather than re-testing gem5 inte
 
 ## How to run
 
-Use the shared local venv:
+Use your project Python environment:
 
 ```bash
-/home/dev/qflex/.venv/bin/python -m pytest -q
+python -m pytest -q
 ```
 
 Run only outer-repo tests:
 
 ```bash
-cd /home/dev/qflex_git
-/home/dev/qflex/.venv/bin/python -m pytest -q
+cd /path/to/qflex
+python -m pytest -q
 ```
 
 Run only integration tests:
 
 ```bash
-cd /home/dev/qflex_git
-/home/dev/qflex/.venv/bin/python -m pytest -q -m integration
+cd /path/to/qflex
+python -m pytest -q -m integration
 ```
 
 Run one specific test:
 
 ```bash
-cd /home/dev/qflex_git
-/home/dev/qflex/.venv/bin/python -m pytest -q tests/test_qpoints_integration.py::test_qflex_run_gem5_ruby_data_trace_cache_dump_and_sim_config
+cd /path/to/qflex
+python -m pytest -q tests/test_qpoints_integration.py::test_qflex_run_gem5_ruby_data_trace_cache_dump_and_sim_config
 ```
 
 ## Test environment file

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -1,0 +1,66 @@
+import importlib.machinery
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+
+def _load_qflex_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "qflex"
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    loader = importlib.machinery.SourceFileLoader("qflex_cli", str(script))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_qflex_qpoints_run_gem5_help_exposes_tracing_options():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "qflex"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "qpoints", "run-gem5", "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "--branch-trace" in result.stdout
+    assert "--data-trace" in result.stdout
+    assert "--dump-cache-state" in result.stdout
+    assert "--timing-ruby" in result.stdout
+    assert "--sim-config" in result.stdout
+
+
+def test_qpoints_run_gem5_forwards_tracing_options():
+    module = _load_qflex_module()
+    with mock.patch.object(module, "qpoints_run_gem5") as forwarded:
+        module.qpoints_run_gem5_cmd(
+            gem5_ckp_dir="/tmp/gem5_ckp",
+            experiment="exp",
+            snapshot="snapshot_0",
+            inst=1000,
+            core_count=1,
+            branch_trace=True,
+            data_trace=True,
+            dump_cache_state=True,
+            timing_ruby=True,
+            sim_config="/tmp/override.args",
+        )
+
+    forwarded.assert_called_once_with(
+        gem5_ckp_dir="/tmp/gem5_ckp",
+        experiment="exp",
+        snapshot="snapshot_0",
+        inst=1000,
+        core_count=1,
+        branch_trace=True,
+        data_trace=True,
+        dump_cache_state=True,
+        timing_ruby=True,
+        sim_config="/tmp/override.args",
+    )

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -5,17 +5,26 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 
 def _load_qflex_module():
     repo_root = Path(__file__).resolve().parents[1]
     script = repo_root / "qflex"
-    if str(repo_root) not in sys.path:
-        sys.path.insert(0, str(repo_root))
-    loader = importlib.machinery.SourceFileLoader("qflex_cli", str(script))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    repo_root_str = str(repo_root)
+    inserted_repo_root = False
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+        inserted_repo_root = True
+    try:
+        loader = importlib.machinery.SourceFileLoader("qflex_cli", str(script))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+    finally:
+        if inserted_repo_root and sys.path and sys.path[0] == repo_root_str:
+            sys.path.pop(0)
 
 
 def test_qflex_qpoints_run_gem5_help_exposes_tracing_options():
@@ -64,3 +73,17 @@ def test_qpoints_run_gem5_forwards_tracing_options():
         timing_ruby=True,
         sim_config="/tmp/override.args",
     )
+
+
+def test_qpoints_run_gem5_rejects_cache_dump_without_ruby():
+    module = _load_qflex_module()
+    with pytest.raises(module.typer.BadParameter, match="requires --timing-ruby"):
+        module.qpoints_run_gem5_cmd(
+            gem5_ckp_dir="/tmp/gem5_ckp",
+            experiment="exp",
+            snapshot="snapshot_0",
+            inst=1000,
+            core_count=1,
+            dump_cache_state=True,
+            timing_ruby=False,
+        )

--- a/tests/test_qpoints_integration.py
+++ b/tests/test_qpoints_integration.py
@@ -64,7 +64,6 @@ def converted_snapshot(repo_root: Path, integration_env, artifact_paths, writabl
     snapshot_dir = Path(integration_env.get("gem5_ckp_dir")) / snapshot
     disk_image = snapshot_dir / f"{snapshot}.img"
     if snapshot_dir.is_dir() and disk_image.is_file():
-        artifact_paths.append(snapshot_dir)
         return snapshot_dir
 
     qflex_script = repo_root / "qflex"

--- a/tests/test_qpoints_integration.py
+++ b/tests/test_qpoints_integration.py
@@ -1,0 +1,227 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from testenv import load_integration_testenv
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_testenv,
+    pytest.mark.slow,
+]
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def qpoints_root(repo_root: Path) -> Path:
+    return repo_root / "QPoints"
+
+
+@pytest.fixture(scope="module")
+def integration_env(repo_root: Path):
+    return load_integration_testenv(
+        repo_root=repo_root,
+        required_keys=("qflex_ckp_dir", "gem5_ckp_dir", "core_count", "memory_gb", "base"),
+    )
+
+
+@pytest.fixture(scope="module")
+def artifact_paths(integration_env):
+    tracked: list[Path] = []
+    yield tracked
+    if integration_env.keep_artifacts():
+        return
+    for path in reversed(tracked):
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        elif path.exists():
+            path.unlink()
+
+
+@pytest.fixture(scope="module")
+def writable_base_image(integration_env, artifact_paths, tmp_path_factory) -> Path:
+    source = Path(integration_env.get("base"))
+    if not source.is_file():
+        pytest.skip(f"Base image not found for integration test: {source}")
+
+    image_dir = tmp_path_factory.mktemp("qflex_image")
+    image_copy = image_dir / source.name
+    shutil.copy2(source, image_copy)
+    artifact_paths.append(image_dir)
+    return image_copy
+
+
+@pytest.fixture(scope="module")
+def converted_snapshot(repo_root: Path, integration_env, artifact_paths, writable_base_image: Path):
+    snapshot = integration_env.snapshot()
+    snapshot_dir = Path(integration_env.get("gem5_ckp_dir")) / snapshot
+    disk_image = snapshot_dir / f"{snapshot}.img"
+    if snapshot_dir.is_dir() and disk_image.is_file():
+        artifact_paths.append(snapshot_dir)
+        return snapshot_dir
+
+    qflex_script = repo_root / "qflex"
+    cmd = [
+        sys.executable,
+        str(qflex_script),
+        "qpoints",
+        "convert-single",
+        "--qflex-ckp-dir",
+        str(integration_env.get("qflex_ckp_dir")),
+        "--gem5-ckp-dir",
+        str(integration_env.get("gem5_ckp_dir")),
+        "--core-count",
+        str(integration_env.get("core_count")),
+        "--memory-gb",
+        str(integration_env.get("memory_gb")),
+        "--base",
+        str(writable_base_image),
+        "--snapshot",
+        snapshot,
+    ]
+
+    optional_args = {
+        "--ssh-host": integration_env.get("ssh_host"),
+        "--ssh-user": integration_env.get("ssh_user"),
+        "--monitor-base": integration_env.get("monitor_base"),
+        "--qmp-base": integration_env.get("qmp_base"),
+        "--ssh-base": integration_env.get("ssh_base"),
+    }
+    for option, value in optional_args.items():
+        if value is not None:
+            cmd.extend([option, str(value)])
+
+    subprocess.run(cmd, check=True, cwd=repo_root)
+
+    assert snapshot_dir.is_dir()
+    assert disk_image.is_file()
+    artifact_paths.append(snapshot_dir)
+    return snapshot_dir
+
+
+def _run_qflex_gem5(
+    repo_root: Path,
+    qpoints_root: Path,
+    integration_env,
+    artifact_paths,
+    experiment: str,
+    *extra_args: str,
+) -> Path:
+    snapshot = integration_env.snapshot()
+    outdir = qpoints_root / "sim_outs" / experiment / snapshot
+    if outdir.exists():
+        shutil.rmtree(outdir)
+
+    cmd = [
+        sys.executable,
+        str(repo_root / "qflex"),
+        "qpoints",
+        "run-gem5",
+        "--gem5-ckp-dir",
+        str(integration_env.get("gem5_ckp_dir")),
+        "--experiment",
+        experiment,
+        "--snapshot",
+        snapshot,
+        "--inst",
+        str(integration_env.insts()),
+        "--core-count",
+        str(integration_env.get("core_count")),
+        *extra_args,
+    ]
+    subprocess.run(cmd, check=True, cwd=repo_root)
+    artifact_paths.append(outdir.parent)
+    return outdir
+
+
+def test_qflex_convert_single_produces_checkpoint_artifacts(converted_snapshot: Path):
+    snapshot = converted_snapshot.name
+    assert converted_snapshot.is_dir()
+    assert (converted_snapshot / f"{snapshot}.img").is_file()
+
+
+def test_qflex_run_gem5_classic_branch_and_data_trace(
+    repo_root: Path,
+    qpoints_root: Path,
+    integration_env,
+    artifact_paths,
+    converted_snapshot: Path,
+):
+    outdir = _run_qflex_gem5(
+        repo_root,
+        qpoints_root,
+        integration_env,
+        artifact_paths,
+        "pytest_qflex_classic_branch_data_100k",
+        "--branch-trace",
+        "--data-trace",
+    )
+
+    assert (outdir / "stats.txt").is_file()
+    assert (outdir / "branch_trace_core_0.log").is_file()
+    assert (outdir / "data_trace_core_0.log").is_file()
+
+
+def test_qflex_run_gem5_classic_sim_config(
+    repo_root: Path,
+    qpoints_root: Path,
+    integration_env,
+    artifact_paths,
+    converted_snapshot: Path,
+    tmp_path: Path,
+):
+    sim_config = tmp_path / "classic_override.args"
+    sim_config.write_text(
+        "# exercise additive classic sim-config path\n\n  --mem-ranks=4  \n",
+        encoding="utf-8",
+    )
+
+    outdir = _run_qflex_gem5(
+        repo_root,
+        qpoints_root,
+        integration_env,
+        artifact_paths,
+        "pytest_qflex_classic_simconfig_100k",
+        "--data-trace",
+        "--sim-config",
+        str(sim_config),
+    )
+
+    assert (outdir / "stats.txt").is_file()
+    assert (outdir / "data_trace_core_0.log").is_file()
+
+
+def test_qflex_run_gem5_ruby_data_trace_cache_dump_and_sim_config(
+    repo_root: Path,
+    qpoints_root: Path,
+    integration_env,
+    artifact_paths,
+    converted_snapshot: Path,
+    tmp_path: Path,
+):
+    sim_config = tmp_path / "override.args"
+    sim_config.write_text("  --mem-ranks=4  \n", encoding="utf-8")
+
+    outdir = _run_qflex_gem5(
+        repo_root,
+        qpoints_root,
+        integration_env,
+        artifact_paths,
+        "pytest_qflex_ruby_data_dump_100k",
+        "--timing-ruby",
+        "--data-trace",
+        "--dump-cache-state",
+        "--sim-config",
+        str(sim_config),
+    )
+
+    assert (outdir / "stats.txt").is_file()
+    assert (outdir / "data_trace_core_0.log").is_file()
+    assert (outdir / "ruby_l2cache0_dump.txt").is_file()

--- a/tests/test_testenv.py
+++ b/tests/test_testenv.py
@@ -1,0 +1,84 @@
+import json
+
+import pytest
+
+from testenv import (
+    DEFAULT_INSTS,
+    DEFAULT_SNAPSHOT,
+    load_testenv,
+    resolve_testenv_path,
+)
+
+
+def test_resolve_testenv_prefers_env_override(tmp_path, monkeypatch):
+    override = tmp_path / "override.json"
+    override.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("QFLEX_TEST_CONFIG", str(override))
+
+    found = resolve_testenv_path(repo_root=tmp_path)
+
+    assert found == override
+
+
+def test_load_testenv_from_repo_local_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
+    config = tmp_path / ".testenv.json"
+    config.write_text(json.dumps({"snapshot": "snapshot_0"}), encoding="utf-8")
+
+    env = load_testenv(repo_root=tmp_path, required_keys=("snapshot",))
+
+    assert env.path == config
+    assert env.get("snapshot") == "snapshot_0"
+
+
+def test_load_testenv_reports_missing_required_keys(tmp_path, monkeypatch):
+    monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
+    config = tmp_path / ".testenv.json"
+    config.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="missing required keys"):
+        load_testenv(repo_root=tmp_path, required_keys=("gem5_ckp_dir",))
+
+
+def test_load_testenv_uses_integration_defaults(tmp_path, monkeypatch):
+    monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
+    config = tmp_path / ".testenv.json"
+    config.write_text("{}", encoding="utf-8")
+
+    env = load_testenv(repo_root=tmp_path)
+
+    assert env.snapshot() == DEFAULT_SNAPSHOT
+    assert env.insts() == DEFAULT_INSTS
+
+
+def test_keep_artifacts_defaults_to_false(tmp_path, monkeypatch):
+    monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
+    monkeypatch.delenv("QFLEX_TEST_KEEP_ARTIFACTS", raising=False)
+    config = tmp_path / ".testenv.json"
+    config.write_text("{}", encoding="utf-8")
+
+    env = load_testenv(repo_root=tmp_path)
+
+    assert env.keep_artifacts() is False
+
+
+def test_keep_artifacts_can_be_enabled_by_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
+    monkeypatch.delenv("QFLEX_TEST_KEEP_ARTIFACTS", raising=False)
+    config = tmp_path / ".testenv.json"
+    config.write_text(json.dumps({"keep_artifacts": True}), encoding="utf-8")
+
+    env = load_testenv(repo_root=tmp_path)
+
+    assert env.keep_artifacts() is True
+
+
+def test_keep_artifacts_env_override_wins(tmp_path, monkeypatch):
+    monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
+    monkeypatch.setenv("QFLEX_TEST_KEEP_ARTIFACTS", "1")
+    config = tmp_path / ".testenv.json"
+    config.write_text(json.dumps({"keep_artifacts": False}), encoding="utf-8")
+
+    env = load_testenv(repo_root=tmp_path)
+
+    assert env.keep_artifacts() is True

--- a/tests/test_testenv.py
+++ b/tests/test_testenv.py
@@ -20,6 +20,14 @@ def test_resolve_testenv_prefers_env_override(tmp_path, monkeypatch):
     assert found == override
 
 
+def test_resolve_testenv_rejects_missing_env_override(tmp_path, monkeypatch):
+    missing = tmp_path / "missing.json"
+    monkeypatch.setenv("QFLEX_TEST_CONFIG", str(missing))
+
+    with pytest.raises(RuntimeError, match="QFLEX_TEST_CONFIG points to a missing file"):
+        resolve_testenv_path(repo_root=tmp_path)
+
+
 def test_load_testenv_from_repo_local_file(tmp_path, monkeypatch):
     monkeypatch.delenv("QFLEX_TEST_CONFIG", raising=False)
     config = tmp_path / ".testenv.json"

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -1,0 +1,109 @@
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_SNAPSHOT = "snapshot_1"
+DEFAULT_INSTS = 100000
+
+
+def _parse_bool(value, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    raise RuntimeError(f"Expected a boolean-like value, got: {value!r}")
+
+
+@dataclass(frozen=True)
+class TestEnv:
+    path: Path
+    values: dict
+
+    def require(self, *keys: str) -> None:
+        missing = [key for key in keys if key not in self.values]
+        if missing:
+            raise RuntimeError(
+                f"Test environment file {self.path} is missing required keys: "
+                f"{', '.join(missing)}"
+            )
+
+    def get(self, key: str, default=None):
+        return self.values.get(key, default)
+
+    def snapshot(self) -> str:
+        return str(self.get("default_snapshot", DEFAULT_SNAPSHOT))
+
+    def insts(self) -> int:
+        return int(self.get("default_insts", DEFAULT_INSTS))
+
+    def keep_artifacts(self) -> bool:
+        env_override = os.environ.get("QFLEX_TEST_KEEP_ARTIFACTS")
+        if env_override is not None:
+            return _parse_bool(env_override)
+        return _parse_bool(self.get("keep_artifacts"), default=False)
+
+
+def candidate_paths(repo_root: Path) -> list[Path]:
+    env_override = os.environ.get("QFLEX_TEST_CONFIG")
+    candidates = []
+    if env_override:
+        candidates.append(Path(env_override).expanduser())
+    candidates.append(repo_root / ".testenv.json")
+    candidates.append(Path.home() / ".config" / "qflex" / "testenv.json")
+    return candidates
+
+
+def resolve_testenv_path(
+    repo_root: Path | None = None,
+    extra_candidates: Iterable[Path] = (),
+) -> Path | None:
+    root = repo_root or Path(__file__).resolve().parents[1]
+    for candidate in [*candidate_paths(root), *extra_candidates]:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_testenv(
+    repo_root: Path | None = None,
+    required_keys: Iterable[str] = (),
+    extra_candidates: Iterable[Path] = (),
+) -> TestEnv:
+    path = resolve_testenv_path(repo_root=repo_root, extra_candidates=extra_candidates)
+    if path is None:
+        raise RuntimeError(
+            "No test environment config found. Set QFLEX_TEST_CONFIG or create "
+            ".testenv.json in the repo root or ~/.config/qflex/testenv.json."
+        )
+
+    values = json.loads(path.read_text(encoding="utf-8"))
+    env = TestEnv(path=path, values=values)
+    if required_keys:
+        env.require(*required_keys)
+    return env
+
+
+def load_integration_testenv(
+    repo_root: Path | None = None,
+    required_keys: Iterable[str] = (),
+    extra_candidates: Iterable[Path] = (),
+) -> TestEnv:
+    try:
+        return load_testenv(
+            repo_root=repo_root,
+            required_keys=required_keys,
+            extra_candidates=extra_candidates,
+        )
+    except RuntimeError as exc:
+        import pytest
+
+        pytest.skip(str(exc))

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -67,6 +67,13 @@ def resolve_testenv_path(
     extra_candidates: Iterable[Path] = (),
 ) -> Path | None:
     root = repo_root or Path(__file__).resolve().parents[1]
+    env_override = os.environ.get("QFLEX_TEST_CONFIG")
+    if env_override:
+        override_path = Path(env_override).expanduser()
+        if not override_path.is_file():
+            raise RuntimeError(
+                f"QFLEX_TEST_CONFIG points to a missing file: {override_path}"
+            )
     for candidate in [*candidate_paths(root), *extra_candidates]:
         if candidate.is_file():
             return candidate


### PR DESCRIPTION
## Summary

This PR brings the outer `qflex` repo up to date with the checkpoint-conversion and tracing work that has already landed in `gem5_ckp_conversion` for `gem5` and `QPoints`.

At a high level it does four things:

- fixes host-side path resolution so the repo can find `kraken_out` from the actual repo root
- adds monitor-based control for `test-worm` so QEMU shutdown is handled more reliably
- exposes the tracing/config knobs needed to drive the merged QPoints/gem5 stack from the top-level CLI
- adds pytest coverage for the outer wrapper contract and updates the `QPoints` submodule to the merged `gem5_ckp_conversion` state

## Changes

### Host path handling
- resolve `kraken_out` relative to the outer repo root instead of assuming a fixed host path

### `test-worm` control flow
- add monitor support to `test-worm`
- keep the working writable-image conversion path intact rather than reverting to the earlier broken read-only behavior

### Top-level tracing CLI
- extend `qflex qpoints run-gem5` to pass through:
  - `--branch-trace`
  - `--data-trace`
  - `--dump-cache-state`
  - `--timing-ruby`
  - `--sim-config`
- update the `QPoints` submodule pointer to the merged `gem5_ckp_conversion` state so the outer CLI drives the current validated stack

### Test coverage
- add an outer-repo pytest suite for:
  - testenv resolution
  - `qflex qpoints run-gem5` CLI surface/forwarding
  - integration coverage for:
    - `qflex qpoints convert-single`
    - classic Atomic gem5 runs with tracing and `--sim-config`
    - Ruby O3 gem5 runs with data trace, cache dump, and `--sim-config`
- document the test harness in `tests/README.md`
- keep integration tests safe by default:
  - use `snapshot_1`
  - run `100000` instructions by default
  - create an isolated writable qcow2 copy
  - clean test-created artifacts unless keep mode is requested

## Validation

I validated the outer wrapper locally with the repo pytest suite:

```bash
cd /home/dev/qflex_git
/home/dev/qflex/.venv/bin/python -m pytest -q
```

Result:
- `9 passed, 4 skipped`

I also exercised the real integration flow earlier in this stack with:
- `snapshot_1`
- `100000` instructions
- successful `qflex qpoints convert-single`
- successful classic Atomic and Ruby O3 `run-gem5` flows through the outer CLI

## Notes

The known writable-qcow2 concern in `run_qemu_emu.sh` remains a deliberate follow-up item. This PR keeps the writable conversion path because that is the currently correct behavior for checkpoint conversion; the graceful end state is an explicit writable copy/overlay mode rather than silently mutating a canonical base image.
