### PR TITLE
qpoints: prepare gem5 uarch artifacts from qflex CLI

### DIFF
--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -81,9 +81,19 @@ def _prepare_snapshot_gem5_uarch(
         )
         return
 
-    prepare_script = _require_qpoints_file(
-        qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
-    )
+    try:
+        prepare_script = _require_qpoints_file(
+            qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
+        )
+    except RuntimeError:
+        print(
+            f"[{snapshot}] prepare_gem5_uarch.py not found; skipping gem5 "
+            f"uarch preparation for {qflex_uarch_dir}",
+            file=sys.stderr,
+        )
+        return
+
+    print(f"[{snapshot}] preparing gem5 uarch artifacts")
     try:
         subprocess.run(
             [
@@ -372,8 +382,6 @@ def convert_single(
             raise RuntimeError(
                 f"[{snapshot}] Converted image not found: {converted_img_tmp}"
             )
-
-        print(f"[{snapshot}] preparing gem5 uarch artifacts")
         _check_cancelled()
         _prepare_snapshot_gem5_uarch(
             qpoints_root, qflex_ckp_dir, gem5_ckp_dir, snapshot

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -60,6 +60,54 @@ def _refresh_qpoints_helper(
     return dest
 
 
+def _prepare_snapshot_gem5_uarch(
+    qpoints_root: Path,
+    qflex_ckp_dir: str,
+    gem5_ckp_dir: str,
+    snapshot: str,
+) -> None:
+    qflex_uarch_dir = Path(qflex_ckp_dir) / "run" / f"{snapshot}.uarch"
+    if not qflex_uarch_dir.is_dir():
+        print(
+            f"[{snapshot}] no qflex uarch directory found at {qflex_uarch_dir}; "
+            "skipping gem5 uarch preparation"
+        )
+        return
+    if shutil.which("zstd") is None:
+        print(
+            f"[{snapshot}] zstd not found; skipping gem5 uarch preparation "
+            f"for {qflex_uarch_dir}",
+            file=sys.stderr,
+        )
+        return
+
+    prepare_script = _require_qpoints_file(
+        qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
+    )
+    try:
+        subprocess.run(
+            [
+                "python3",
+                str(prepare_script),
+                "--qflex-run-dir",
+                str(Path(qflex_ckp_dir) / "run"),
+                "--gem5-workload-root",
+                gem5_ckp_dir,
+                "--snapshot",
+                snapshot,
+                "--overwrite",
+            ],
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        print(
+            f"[{snapshot}] gem5 uarch preparation failed for "
+            f"{qflex_uarch_dir}; continuing without gem5 uarch artifacts",
+            file=sys.stderr,
+        )
+
+
 def _positive_int_env(name: str, default: int) -> int:
     value = os.environ.get(name, str(default))
     if not re.fullmatch(r"[1-9][0-9]*", value):
@@ -324,6 +372,12 @@ def convert_single(
             raise RuntimeError(
                 f"[{snapshot}] Converted image not found: {converted_img_tmp}"
             )
+
+        print(f"[{snapshot}] preparing gem5 uarch artifacts")
+        _check_cancelled()
+        _prepare_snapshot_gem5_uarch(
+            qpoints_root, qflex_ckp_dir, gem5_ckp_dir, snapshot
+        )
     except KeyboardInterrupt:
         _terminate_qemu()
         raise

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -97,7 +97,7 @@ def _prepare_snapshot_gem5_uarch(
     try:
         subprocess.run(
             [
-                "python3",
+                sys.executable,
                 str(prepare_script),
                 "--qflex-run-dir",
                 str(Path(qflex_ckp_dir) / "run"),

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -27,6 +27,22 @@ def _load_qflex_module():
             sys.path.pop(0)
 
 
+def _load_qpoints_commands_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_str = str(repo_root)
+    inserted_repo_root = False
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+        inserted_repo_root = True
+    try:
+        from commands import qpoints as module
+
+        return module
+    finally:
+        if inserted_repo_root and sys.path and sys.path[0] == repo_root_str:
+            sys.path.pop(0)
+
+
 def test_qflex_qpoints_run_gem5_help_exposes_tracing_options():
     repo_root = Path(__file__).resolve().parents[1]
     script = repo_root / "qflex"
@@ -87,3 +103,116 @@ def test_qpoints_run_gem5_rejects_cache_dump_without_ruby():
             dump_cache_state=True,
             timing_ruby=False,
         )
+
+
+def test_prepare_snapshot_gem5_uarch_skips_when_qflex_uarch_missing(capsys):
+    module = _load_qpoints_commands_module()
+    with mock.patch.object(module.subprocess, "run") as run_mock:
+        module._prepare_snapshot_gem5_uarch(
+            qpoints_root=Path("/tmp/qpoints-root"),
+            qflex_ckp_dir="/tmp/qflex-ckpts",
+            gem5_ckp_dir="/tmp/gem5-ckpts",
+            snapshot="snapshot_0",
+        )
+
+    run_mock.assert_not_called()
+    assert "skipping gem5 uarch preparation" in capsys.readouterr().out
+
+
+def test_prepare_snapshot_gem5_uarch_invokes_qpoints_postprocessor(tmp_path: Path):
+    module = _load_qpoints_commands_module()
+
+    qpoints_root = tmp_path / "QPoints"
+    script_path = qpoints_root / "scripts" / "uarch_restore" / "prepare_gem5_uarch.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("#!/usr/bin/env python3\n")
+
+    qflex_ckp_dir = tmp_path / "qflex-ckpts"
+    (qflex_ckp_dir / "run" / "snapshot_0.uarch").mkdir(parents=True)
+    gem5_ckp_dir = tmp_path / "checkpoints"
+    gem5_ckp_dir.mkdir()
+
+    with mock.patch.object(module.shutil, "which", return_value="/usr/bin/zstd"), \
+         mock.patch.object(module.subprocess, "run") as run_mock:
+        module._prepare_snapshot_gem5_uarch(
+            qpoints_root=qpoints_root,
+            qflex_ckp_dir=str(qflex_ckp_dir),
+            gem5_ckp_dir=str(gem5_ckp_dir),
+            snapshot="snapshot_0",
+        )
+
+    run_mock.assert_called_once_with(
+        [
+            "python3",
+            str(script_path),
+            "--qflex-run-dir",
+            str(qflex_ckp_dir / "run"),
+            "--gem5-workload-root",
+            str(gem5_ckp_dir),
+            "--snapshot",
+            "snapshot_0",
+            "--overwrite",
+        ],
+        text=True,
+        check=True,
+    )
+
+
+def test_prepare_snapshot_gem5_uarch_skips_when_zstd_missing(
+    tmp_path: Path, capsys
+):
+    module = _load_qpoints_commands_module()
+
+    qpoints_root = tmp_path / "QPoints"
+    script_path = qpoints_root / "scripts" / "uarch_restore" / "prepare_gem5_uarch.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("#!/usr/bin/env python3\n")
+
+    qflex_ckp_dir = tmp_path / "qflex-ckpts"
+    (qflex_ckp_dir / "run" / "snapshot_0.uarch").mkdir(parents=True)
+    gem5_ckp_dir = tmp_path / "checkpoints"
+    gem5_ckp_dir.mkdir()
+
+    with mock.patch.object(module.shutil, "which", return_value=None), \
+         mock.patch.object(module.subprocess, "run") as run_mock:
+        module._prepare_snapshot_gem5_uarch(
+            qpoints_root=qpoints_root,
+            qflex_ckp_dir=str(qflex_ckp_dir),
+            gem5_ckp_dir=str(gem5_ckp_dir),
+            snapshot="snapshot_0",
+        )
+
+    run_mock.assert_not_called()
+    assert "zstd not found; skipping gem5 uarch preparation" in capsys.readouterr().err
+
+
+def test_prepare_snapshot_gem5_uarch_continues_when_postprocessor_fails(
+    tmp_path: Path, capsys
+):
+    module = _load_qpoints_commands_module()
+
+    qpoints_root = tmp_path / "QPoints"
+    script_path = qpoints_root / "scripts" / "uarch_restore" / "prepare_gem5_uarch.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("#!/usr/bin/env python3\n")
+
+    qflex_ckp_dir = tmp_path / "qflex-ckpts"
+    (qflex_ckp_dir / "run" / "snapshot_0.uarch").mkdir(parents=True)
+    gem5_ckp_dir = tmp_path / "checkpoints"
+    gem5_ckp_dir.mkdir()
+
+    with mock.patch.object(module.shutil, "which", return_value="/usr/bin/zstd"), \
+         mock.patch.object(
+             module.subprocess,
+             "run",
+             side_effect=subprocess.CalledProcessError(1, ["python3"]),
+         ) as run_mock:
+        module._prepare_snapshot_gem5_uarch(
+            qpoints_root=qpoints_root,
+            qflex_ckp_dir=str(qflex_ckp_dir),
+            gem5_ckp_dir=str(gem5_ckp_dir),
+            snapshot="snapshot_0",
+        )
+
+    run_mock.assert_called_once()
+    assert "continuing without gem5 uarch artifacts" in capsys.readouterr().err

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -143,7 +143,7 @@ def test_prepare_snapshot_gem5_uarch_invokes_qpoints_postprocessor(tmp_path: Pat
 
     run_mock.assert_called_once_with(
         [
-            "python3",
+            module.sys.executable,
             str(script_path),
             "--qflex-run-dir",
             str(qflex_ckp_dir / "run"),

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -216,3 +216,31 @@ def test_prepare_snapshot_gem5_uarch_continues_when_postprocessor_fails(
 
     run_mock.assert_called_once()
     assert "continuing without gem5 uarch artifacts" in capsys.readouterr().err
+
+
+def test_prepare_snapshot_gem5_uarch_skips_when_postprocessor_script_missing(
+    tmp_path: Path, capsys
+):
+    module = _load_qpoints_commands_module()
+
+    qpoints_root = tmp_path / "QPoints"
+    qpoints_root.mkdir()
+
+    qflex_ckp_dir = tmp_path / "qflex-ckpts"
+    (qflex_ckp_dir / "run" / "snapshot_0.uarch").mkdir(parents=True)
+    gem5_ckp_dir = tmp_path / "checkpoints"
+    gem5_ckp_dir.mkdir()
+
+    with mock.patch.object(module.shutil, "which", return_value="/usr/bin/zstd"), \
+         mock.patch.object(module.subprocess, "run") as run_mock:
+        module._prepare_snapshot_gem5_uarch(
+            qpoints_root=qpoints_root,
+            qflex_ckp_dir=str(qflex_ckp_dir),
+            gem5_ckp_dir=str(gem5_ckp_dir),
+            snapshot="snapshot_0",
+        )
+
+    run_mock.assert_not_called()
+    assert "prepare_gem5_uarch.py not found; skipping gem5 uarch preparation" in (
+        capsys.readouterr().err
+    )


### PR DESCRIPTION
## Summary
- update the `QPoints` submodule to merged `gem5-integration/main`
- prepare `snapshot_X.gem5_uarch` artifacts from the outer `qflex qpoints convert-single` flow
- align outer CLI behavior with QPoints by skipping optional uarch prep when inputs or `zstd` are unavailable and continuing on prep failures
- add outer CLI tests for the new qpoints post-processing path

## Validation
- `/home/dev/qflex/.venv/bin/python -m pytest -q tests/test_qpoints_cli.py`

## Notes
- This is the user-facing integration layer on top of the merged QPoints and gem5 support.
- `convert-multi` inherits the same behavior through `convert_single`.
