### PR TITLE
qpoints: Recover restore-infra CLI wiring

### DIFF
--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -81,23 +81,13 @@ def _prepare_snapshot_gem5_uarch(
         )
         return
 
-    try:
-        prepare_script = _require_qpoints_file(
-            qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
-        )
-    except RuntimeError:
-        print(
-            f"[{snapshot}] prepare_gem5_uarch.py not found; skipping gem5 "
-            f"uarch preparation for {qflex_uarch_dir}",
-            file=sys.stderr,
-        )
-        return
-
-    print(f"[{snapshot}] preparing gem5 uarch artifacts")
+    prepare_script = _require_qpoints_file(
+        qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
+    )
     try:
         subprocess.run(
             [
-                sys.executable,
+                "python3",
                 str(prepare_script),
                 "--qflex-run-dir",
                 str(Path(qflex_ckp_dir) / "run"),
@@ -382,6 +372,8 @@ def convert_single(
             raise RuntimeError(
                 f"[{snapshot}] Converted image not found: {converted_img_tmp}"
             )
+
+        print(f"[{snapshot}] preparing gem5 uarch artifacts")
         _check_cancelled()
         _prepare_snapshot_gem5_uarch(
             qpoints_root, qflex_ckp_dir, gem5_ckp_dir, snapshot

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -81,9 +81,19 @@ def _prepare_snapshot_gem5_uarch(
         )
         return
 
-    prepare_script = _require_qpoints_file(
-        qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
-    )
+    try:
+        prepare_script = _require_qpoints_file(
+            qpoints_root, "scripts/uarch_restore/prepare_gem5_uarch.py"
+        )
+    except RuntimeError:
+        print(
+            f"[{snapshot}] prepare_gem5_uarch.py not found; skipping gem5 "
+            f"uarch preparation for {qflex_uarch_dir}",
+            file=sys.stderr,
+        )
+        return
+
+    print(f"[{snapshot}] preparing gem5 uarch artifacts")
     try:
         subprocess.run(
             [
@@ -372,8 +382,6 @@ def convert_single(
             raise RuntimeError(
                 f"[{snapshot}] Converted image not found: {converted_img_tmp}"
             )
-
-        print(f"[{snapshot}] preparing gem5 uarch artifacts")
         _check_cancelled()
         _prepare_snapshot_gem5_uarch(
             qpoints_root, qflex_ckp_dir, gem5_ckp_dir, snapshot

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -97,7 +97,7 @@ def _prepare_snapshot_gem5_uarch(
     try:
         subprocess.run(
             [
-                "python3",
+                sys.executable,
                 str(prepare_script),
                 "--qflex-run-dir",
                 str(Path(qflex_ckp_dir) / "run"),

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -143,7 +143,7 @@ def test_prepare_snapshot_gem5_uarch_invokes_qpoints_postprocessor(tmp_path: Pat
 
     run_mock.assert_called_once_with(
         [
-            "python3",
+            module.sys.executable,
             str(script_path),
             "--qflex-run-dir",
             str(qflex_ckp_dir / "run"),

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -216,3 +216,31 @@ def test_prepare_snapshot_gem5_uarch_continues_when_postprocessor_fails(
 
     run_mock.assert_called_once()
     assert "continuing without gem5 uarch artifacts" in capsys.readouterr().err
+
+
+def test_prepare_snapshot_gem5_uarch_skips_when_postprocessor_script_missing(
+    tmp_path: Path, capsys
+):
+    module = _load_qpoints_commands_module()
+
+    qpoints_root = tmp_path / "QPoints"
+    qpoints_root.mkdir()
+
+    qflex_ckp_dir = tmp_path / "qflex-ckpts"
+    (qflex_ckp_dir / "run" / "snapshot_0.uarch").mkdir(parents=True)
+    gem5_ckp_dir = tmp_path / "checkpoints"
+    gem5_ckp_dir.mkdir()
+
+    with mock.patch.object(module.shutil, "which", return_value="/usr/bin/zstd"), \
+         mock.patch.object(module.subprocess, "run") as run_mock:
+        module._prepare_snapshot_gem5_uarch(
+            qpoints_root=qpoints_root,
+            qflex_ckp_dir=str(qflex_ckp_dir),
+            gem5_ckp_dir=str(gem5_ckp_dir),
+            snapshot="snapshot_0",
+        )
+
+    run_mock.assert_not_called()
+    assert "prepare_gem5_uarch.py not found; skipping gem5 uarch preparation" in (
+        capsys.readouterr().err
+    )

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -143,7 +143,7 @@ def test_prepare_snapshot_gem5_uarch_invokes_qpoints_postprocessor(tmp_path: Pat
 
     run_mock.assert_called_once_with(
         [
-            module.sys.executable,
+            "python3",
             str(script_path),
             "--qflex-run-dir",
             str(qflex_ckp_dir / "run"),
@@ -216,31 +216,3 @@ def test_prepare_snapshot_gem5_uarch_continues_when_postprocessor_fails(
 
     run_mock.assert_called_once()
     assert "continuing without gem5 uarch artifacts" in capsys.readouterr().err
-
-
-def test_prepare_snapshot_gem5_uarch_skips_when_postprocessor_script_missing(
-    tmp_path: Path, capsys
-):
-    module = _load_qpoints_commands_module()
-
-    qpoints_root = tmp_path / "QPoints"
-    qpoints_root.mkdir()
-
-    qflex_ckp_dir = tmp_path / "qflex-ckpts"
-    (qflex_ckp_dir / "run" / "snapshot_0.uarch").mkdir(parents=True)
-    gem5_ckp_dir = tmp_path / "checkpoints"
-    gem5_ckp_dir.mkdir()
-
-    with mock.patch.object(module.shutil, "which", return_value="/usr/bin/zstd"), \
-         mock.patch.object(module.subprocess, "run") as run_mock:
-        module._prepare_snapshot_gem5_uarch(
-            qpoints_root=qpoints_root,
-            qflex_ckp_dir=str(qflex_ckp_dir),
-            gem5_ckp_dir=str(gem5_ckp_dir),
-            snapshot="snapshot_0",
-        )
-
-    run_mock.assert_not_called()
-    assert "prepare_gem5_uarch.py not found; skipping gem5 uarch preparation" in (
-        capsys.readouterr().err
-    )


### PR DESCRIPTION
This PR recovers the shared restore-infrastructure branch for the top-level qflex CLI.

Scope:
- gem5 uarch preparation wiring from `qflex`
- active-Python handoff for restore preparation
- optional prep/refinement plumbing used by downstream feature stacks

This is the base PR for the stacked `l1d`, `l1i`, `btb`, and `tage` qflex review PRs.