### PR TITLE
fw: support gem5 BBL BTB capture

### DIFF
--- a/commands/functional_warming.py
+++ b/commands/functional_warming.py
@@ -1,8 +1,11 @@
 import math
+import re
+from pathlib import Path
 
 from commands import Executor
 from .config import ExperimentContext
-from commands.qemu import QemuCommonArgParser   
+from commands.qemu import QemuCommonArgParser
+
 
 class FunctionalWarming(Executor):
     """
@@ -11,26 +14,47 @@ class FunctionalWarming(Executor):
 
     def __init__(self,
                  experiment_context: ExperimentContext,
-                 sample_size: int):
+                 sample_size: int,
+                 collect_gem5_bbl_btb: bool = False):
         self.experiment_context = experiment_context
         self.simulation_context = self.experiment_context.simulation_context
         self.qemu_common_parser = QemuCommonArgParser(experiment_context)
         self.sample_size = sample_size
+        self.collect_gem5_bbl_btb = collect_gem5_bbl_btb
         self.sampling_interval = math.ceil(
             (self.experiment_context.workload.population + self.sample_size - 1) / self.sample_size
         )
 
-
-
-    
+    def next_snapshot_init_index(self) -> int:
+        run_dir = Path(self.experiment_context.get_experiment_folder_address()) / "run"
+        pattern = re.compile(r"snapshot_(\d+)(?:$|\.)")
+        max_index = -1
+        for path in run_dir.iterdir():
+            match = pattern.match(path.name)
+            if match:
+                max_index = max(max_index, int(match.group(1)))
+        return max_index + 1
 
     def cmd(self) -> str:
+        init_index = self.next_snapshot_init_index()
+        plugin_args = [
+            "mode=warm",
+            f"init_threshold={self.sampling_interval}",
+            f"interval={self.sampling_interval}",
+            f"count={self.sample_size}",
+            "prefix=snapshot",
+            f"init_index={init_index}",
+        ]
+        if self.collect_gem5_bbl_btb:
+            plugin_args.append("collect_gem5_bbl_btb=1")
+        plugin_arg_string = ",".join(plugin_args)
         fw_cmd = f"""
             ./qemu-system-aarch64 \
             {self.qemu_common_parser.get_qemu_base_args()} \
             {self.qemu_common_parser.quantum_args()} \
-            -plugin ../lib/libworm_cache.so,mode=warm,init_threshold={self.sampling_interval},interval={self.sampling_interval},count={self.sample_size} \
+            -plugin ../lib/libworm_cache.so,{plugin_arg_string} \
         """
+        print(f"Functional warming will start emitting snapshots at snapshot_{init_index}.")
         print("fw command:")
         print(fw_cmd)
         return [

--- a/qflex
+++ b/qflex
@@ -167,6 +167,9 @@ def fw(
     sample_size: Annotated[int, typer.Option(
         help="Sample size for the workload."
     )]=30,
+    collect_gem5_bbl_btb: Annotated[bool, typer.Option(
+        help="Whether to collect the export-only gem5 BBL-BTB view alongside the live PC-indexed BTB during functional warming."
+    )]=False,
 ):
     """
     This command performs functional warming of the simulator.
@@ -175,6 +178,7 @@ def fw(
     functional_warm_executor = FunctionalWarming(
         experiment_context=experiment_context,
         sample_size=sample_size,
+        collect_gem5_bbl_btb=collect_gem5_bbl_btb,
     )
     functional_warm_executor.execute(to_stdio=True, run_in_background=False)
 


### PR DESCRIPTION
Summary
- add a top-level functional warming option to request the export-only gem5 BBL-BTB view
- plumb that option into the WormCache plugin arguments used during functional warming
- assign the initial snapshot index from existing snapshot files so repeated warming runs continue numbering cleanly

Notes
- root-only qflex workflow change
- no gem5 or QPoints code changes in this PR