### PR TITLE
qflex: support serial multi-snapshot gem5 runs

### DIFF
--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -247,10 +247,13 @@ def _is_checkpoint_ready_for_request(
             dtb_size=dtb_size,
             have_large_asid_64=have_large_asid_64,
         )
-    except RuntimeError:
+    except (RuntimeError, ValueError, json.JSONDecodeError):
         return False
 
-    manifest = _load_protocol_uarch_manifest(checkpoint_dir, ruby_protocol)
+    try:
+        manifest = _load_protocol_uarch_manifest(checkpoint_dir, ruby_protocol)
+    except (ValueError, json.JSONDecodeError):
+        return False
     if not manifest:
         return False
     if runtime_llc_slice_count is not None:

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -186,6 +186,96 @@ def _validate_staged_llc_slice_count(
         )
 
 
+def _is_gem_bundle_ready(run_dir: Path, snapshot: str) -> bool:
+    gem_dir = run_dir / f"{snapshot}.gem"
+    required_files = (
+        gem_dir / "register-info.json",
+        gem_dir / "dev.info",
+        gem_dir / "system.physmem.store1.pmem",
+    )
+    return all(path.is_file() for path in required_files)
+
+
+def _is_checkpoint_ready(
+    gem5_ckp_dir: str,
+    snapshot: str,
+    ruby_protocol: str,
+) -> bool:
+    checkpoint_dir = Path(gem5_ckp_dir) / snapshot
+    required_files = (
+        checkpoint_dir / "machine_config.json",
+        checkpoint_dir / "m5.cpt",
+        checkpoint_dir / f"{snapshot}.img",
+        checkpoint_dir / "system.physmem.store0.pmem",
+        checkpoint_dir / "system.physmem.store1.pmem",
+        checkpoint_dir / "register-info.json",
+        checkpoint_dir / "dev.info",
+        checkpoint_dir / "gem5_uarch" / ruby_protocol / "manifest.json",
+    )
+    return all(path.exists() for path in required_files)
+
+
+def _is_checkpoint_ready_for_request(
+    gem5_ckp_dir: str,
+    snapshot: str,
+    ruby_protocol: str,
+    *,
+    core_count: int,
+    memory_gb: int,
+    kernel: str,
+    bootloader: str,
+    root_device: str,
+    itb_size: int,
+    dtb_size: int,
+    have_large_asid_64: bool,
+) -> bool:
+    if not _is_checkpoint_ready(gem5_ckp_dir, snapshot, ruby_protocol):
+        return False
+
+    checkpoint_dir = Path(gem5_ckp_dir) / snapshot
+    try:
+        machine_config = _load_machine_config(checkpoint_dir / "machine_config.json")
+        _validate_machine_config(
+            machine_config,
+            core_count=core_count,
+            memory_gb=memory_gb,
+            kernel=kernel,
+            bootloader=bootloader,
+            root_device=root_device,
+            itb_size=itb_size,
+            dtb_size=dtb_size,
+            have_large_asid_64=have_large_asid_64,
+        )
+    except RuntimeError:
+        return False
+
+    manifest = _load_protocol_uarch_manifest(checkpoint_dir, ruby_protocol)
+    if not manifest:
+        return False
+
+    tlb_source_files = (
+        manifest.get("components", {})
+        .get("tlb", {})
+        .get("source_files", {})
+    )
+    gem5_uarch_dir = checkpoint_dir / "gem5_uarch"
+    for cpu_str in tlb_source_files:
+        mmu_cpt = gem5_uarch_dir / f"mmu-cpu{cpu_str}.cpt"
+        if not mmu_cpt.is_file():
+            return False
+
+    return True
+
+
+def _cleanup_snapshot_gem5_artifacts(
+    qflex_ckp_dir: str,
+    gem5_ckp_dir: str,
+    snapshot: str,
+) -> None:
+    _remove_path(Path(qflex_ckp_dir) / "run" / f"{snapshot}.gem")
+    _remove_path(Path(gem5_ckp_dir) / snapshot)
+
+
 def _refresh_qpoints_helper(
     qpoints_root: Path,
     run_dir: Path,
@@ -1035,7 +1125,7 @@ def convert_single(
     kernel: Optional[str],
     bootloader: Optional[str],
     root_device: str,
-    base: str,
+    base: Optional[str],
     snapshot: str,
     sim_config: Optional[str] = None,
     ssh_host: str = "127.0.0.1",
@@ -1071,6 +1161,12 @@ def convert_single(
     experiment_kernel_dir, experiment_kernel_path = _require_ready_experiment_kernel(
         experiment_machine_config
     )
+    if not base:
+        image_path = experiment_machine_config.get("image_path", "")
+        if image_path:
+            base = str(Path(image_path).expanduser().resolve())
+    if not base:
+        raise RuntimeError("Base image path is not available for convert-single.")
     Path(gem5_ckp_dir).mkdir(parents=True, exist_ok=True)
     checkpoint_kernel_dir = _ensure_checkpoint_kernel_link(
         Path(gem5_ckp_dir), experiment_kernel_dir
@@ -1088,8 +1184,24 @@ def convert_single(
     register_info = qemu_gem5_dump_dir / "register-info.json"
     dev_info = qemu_gem5_dump_dir / "dev.info"
     physmem = qemu_gem5_dump_dir / "system.physmem.store1.pmem"
-    checkpoint_files_exist = (
-        register_info.is_file() and dev_info.is_file() and physmem.is_file()
+    gem_bundle_ready = _is_gem_bundle_ready(run_dir, snapshot)
+    resolved_bootloader = (
+        str(Path(bootloader).expanduser().resolve())
+        if bootloader
+        else get_default_bootloader_path()
+    )
+    checkpoint_ready = _is_checkpoint_ready_for_request(
+        gem5_ckp_dir,
+        snapshot,
+        ruby_protocol,
+        core_count=core_count,
+        memory_gb=memory_gb,
+        kernel=checkpoint_kernel_path,
+        bootloader=resolved_bootloader,
+        root_device=root_device,
+        itb_size=resolved_itb_size,
+        dtb_size=resolved_dtb_size,
+        have_large_asid_64=resolved_have_large_asid_64,
     )
 
     qemu_bin = run_dir / "qemu-system-aarch64"
@@ -1111,9 +1223,18 @@ def convert_single(
             raise RuntimeError(f"[{snapshot}] conversion cancelled")
     try:
         _check_cancelled()
+        if checkpoint_ready and not overwrite:
+            print(f"[{snapshot}] checkpoint already ready; skipping conversion")
+            return
+
         if img_dest_dir.exists():
             if overwrite:
                 _remove_path(img_dest_dir)
+            elif not checkpoint_ready:
+                print(
+                    f"[{snapshot}] checkpoint exists but is incomplete; "
+                    "continuing conversion"
+                )
             elif sys.stdin.isatty():
                 resp = input(
                     f"Destination directory already exists: {img_dest_dir}\n"
@@ -1128,7 +1249,7 @@ def convert_single(
                     "Re-run with --overwrite to remove it."
                 )
 
-        if not checkpoint_files_exist:
+        if not gem_bundle_ready:
             print(f"[{snapshot}] generating .gem checkpoint bundle")
             qemu_cpu = resolve_qemu_cpu()
             with qemu_log.open("w") as log_file:
@@ -1154,8 +1275,9 @@ def convert_single(
                     text=True,
                     check=True,
                 )
+            gem_bundle_ready = _is_gem_bundle_ready(run_dir, snapshot)
 
-        if not qemu_gem5_dump_dir.is_dir():
+        if not gem_bundle_ready or not qemu_gem5_dump_dir.is_dir():
             raise RuntimeError(
                 f"[{snapshot}] expected .gem producer bundle not found: "
                 f"{qemu_gem5_dump_dir}.{_tail_file(qemu_log)}"
@@ -1342,8 +1464,10 @@ def convert_multi(
 
 
 def run_sample(
+    qflex_ckp_dir: str,
     gem5_ckp_dir: str,
     experiment: str,
+    base: str,
     first: str,
     last: str,
     core_count: int,
@@ -1376,6 +1500,23 @@ def run_sample(
     summaries = []
 
     for snapshot in snapshots:
+        ruby_protocol = "mesi_two_level"
+        if timing_ruby_moesi:
+            ruby_protocol = "moesi_cmp_directory"
+        convert_single(
+            qflex_ckp_dir=qflex_ckp_dir,
+            gem5_ckp_dir=gem5_ckp_dir,
+            core_count=core_count,
+            memory_gb=memory_gb,
+            kernel=None,
+            bootloader=bootloader,
+            root_device=root_device,
+            base=base,
+            snapshot=snapshot,
+            sim_config=sim_config,
+            overwrite=False,
+            ruby_protocol=ruby_protocol,
+        )
         run_gem5(
             gem5_ckp_dir=gem5_ckp_dir,
             experiment=experiment,
@@ -1391,6 +1532,11 @@ def run_sample(
             timing_ruby_moesi=timing_ruby_moesi,
             cache_hierarchy_restore=cache_hierarchy_restore,
             sim_config=sim_config,
+        )
+        _cleanup_snapshot_gem5_artifacts(
+            qflex_ckp_dir=qflex_ckp_dir,
+            gem5_ckp_dir=gem5_ckp_dir,
+            snapshot=snapshot,
         )
         summary_path = qpoints_root / "sim_outs" / experiment / snapshot / "uipc_summary.json"
         summaries.append(_load_uipc_summary(summary_path))

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -1480,6 +1480,7 @@ def run_sample(
     timing_ruby_moesi: bool = False,
     cache_hierarchy_restore: bool = True,
     sim_config: Optional[str] = None,
+    cleanup_conversion_artifacts: bool = True,
 ) -> Path:
     if timing_ruby and timing_ruby_moesi:
         raise RuntimeError(
@@ -1533,11 +1534,12 @@ def run_sample(
             cache_hierarchy_restore=cache_hierarchy_restore,
             sim_config=sim_config,
         )
-        _cleanup_snapshot_gem5_artifacts(
-            qflex_ckp_dir=qflex_ckp_dir,
-            gem5_ckp_dir=gem5_ckp_dir,
-            snapshot=snapshot,
-        )
+        if cleanup_conversion_artifacts:
+            _cleanup_snapshot_gem5_artifacts(
+                qflex_ckp_dir=qflex_ckp_dir,
+                gem5_ckp_dir=gem5_ckp_dir,
+                snapshot=snapshot,
+            )
         summary_path = qpoints_root / "sim_outs" / experiment / snapshot / "uipc_summary.json"
         summaries.append(_load_uipc_summary(summary_path))
 

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -220,6 +220,7 @@ def _is_checkpoint_ready_for_request(
     snapshot: str,
     ruby_protocol: str,
     *,
+    runtime_llc_slice_count: Optional[int],
     core_count: int,
     memory_gb: int,
     kernel: str,
@@ -252,6 +253,16 @@ def _is_checkpoint_ready_for_request(
     manifest = _load_protocol_uarch_manifest(checkpoint_dir, ruby_protocol)
     if not manifest:
         return False
+    if runtime_llc_slice_count is not None:
+        staged_llc_slice_count = manifest.get("llc_slice_count")
+        if staged_llc_slice_count is None:
+            return False
+        try:
+            staged_llc_slice_count = int(staged_llc_slice_count)
+        except (TypeError, ValueError):
+            return False
+        if staged_llc_slice_count != runtime_llc_slice_count:
+            return False
 
     tlb_source_files = (
         manifest.get("components", {})
@@ -1190,10 +1201,16 @@ def convert_single(
         if bootloader
         else get_default_bootloader_path()
     )
+    resolved_llc_slice_count = _resolve_llc_slice_count_from_sim_configs(
+        qpoints_root,
+        _default_sim_config_rel_for_ruby_protocol(ruby_protocol),
+        sim_config,
+    )
     checkpoint_ready = _is_checkpoint_ready_for_request(
         gem5_ckp_dir,
         snapshot,
         ruby_protocol,
+        runtime_llc_slice_count=resolved_llc_slice_count,
         core_count=core_count,
         memory_gb=memory_gb,
         kernel=checkpoint_kernel_path,

--- a/commands/qpoints.py
+++ b/commands/qpoints.py
@@ -236,6 +236,8 @@ def _is_checkpoint_ready_for_request(
     checkpoint_dir = Path(gem5_ckp_dir) / snapshot
     try:
         machine_config = _load_machine_config(checkpoint_dir / "machine_config.json")
+        if not isinstance(machine_config, dict):
+            return False
         _validate_machine_config(
             machine_config,
             core_count=core_count,

--- a/qflex
+++ b/qflex
@@ -367,6 +367,13 @@ def run_sample(
             help="Enable or disable gem5 LLC/L1 cache-hierarchy restore flags.",
         ),
     ] = True,
+    cleanup_conversion_artifacts: Annotated[
+        bool,
+        typer.Option(
+            "--cleanup-conversion-artifacts/--no-cleanup-conversion-artifacts",
+            help="Delete or keep derived gem5 conversion artifacts after each successful per-snapshot gem5 run.",
+        ),
+    ] = True,
     sim_config: Annotated[
         str | None,
         typer.Option(help="Optional QPoints/gem5 config args file to pass through to run_gem5.sh."),
@@ -413,6 +420,7 @@ def run_sample(
             timing_ruby=timing_ruby,
             timing_ruby_moesi=timing_ruby_moesi,
             cache_hierarchy_restore=cache_hierarchy_restore,
+            cleanup_conversion_artifacts=cleanup_conversion_artifacts,
             sim_config=sim_config,
         )
         return
@@ -424,6 +432,10 @@ def run_sample(
             )
         if sim_config:
             raise typer.BadParameter("--sim-config is currently gem5-only.")
+        if not cleanup_conversion_artifacts:
+            raise typer.BadParameter(
+                "--no-cleanup-conversion-artifacts is currently gem5-only."
+            )
         if measurement_cycles <= 0:
             raise typer.BadParameter(
                 "--measurement-cycles must be a positive integer."

--- a/qflex
+++ b/qflex
@@ -398,8 +398,10 @@ def run_sample(
                 "--warmup-cycles must be non-negative."
             )
         qpoints_run_sample(
+            qflex_ckp_dir=experiment_context.get_experiment_folder_address(),
             gem5_ckp_dir=resolved_gem5_ckp_dir,
             experiment=experiment,
+            base=experiment_context.get_local_image_address(),
             first=first,
             last=last,
             core_count=core_count,

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -559,6 +559,53 @@ def test_is_checkpoint_ready_for_request_treats_corrupt_metadata_as_not_ready(
     )
 
 
+def test_is_checkpoint_ready_for_request_treats_non_object_machine_config_as_not_ready(
+    tmp_path: Path,
+):
+    module = _load_qpoints_commands_module()
+
+    checkpoint_dir = tmp_path / "snapshot_0"
+    protocol_dir = checkpoint_dir / "gem5_uarch" / "moesi_cmp_directory"
+    protocol_dir.mkdir(parents=True)
+    (checkpoint_dir / "machine_config.json").write_text(
+        "[]\n",
+        encoding="utf-8",
+    )
+    for relative in (
+        "m5.cpt",
+        "snapshot_0.img",
+        "system.physmem.store0.pmem",
+        "system.physmem.store1.pmem",
+        "register-info.json",
+        "dev.info",
+    ):
+        path = checkpoint_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+    (protocol_dir / "manifest.json").write_text(
+        __import__("json").dumps({"llc_slice_count": 8}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        module._is_checkpoint_ready_for_request(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+            runtime_llc_slice_count=8,
+            core_count=8,
+            memory_gb=32,
+            kernel="/tmp/kernel",
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            itb_size=64,
+            dtb_size=64,
+            have_large_asid_64=True,
+        )
+        is False
+    )
+
+
 def test_run_sample_converts_each_snapshot_before_running_gem5():
     module = _load_qpoints_commands_module()
 

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -355,6 +355,7 @@ def test_is_checkpoint_ready_for_request_rejects_machine_contract_mismatch(
             str(tmp_path),
             "snapshot_0",
             "moesi_cmp_directory",
+            runtime_llc_slice_count=8,
             core_count=8,
             memory_gb=32,
             kernel="/tmp/kernel",
@@ -403,7 +404,10 @@ def test_is_checkpoint_ready_for_request_requires_mmu_sidecars_when_tlb_present(
         path.write_text("{}\n", encoding="utf-8")
     (protocol_dir / "manifest.json").write_text(
         __import__("json").dumps(
-            {"components": {"tlb": {"source_files": {"0": "cpu0.json"}}}}
+            {
+                "llc_slice_count": 8,
+                "components": {"tlb": {"source_files": {"0": "cpu0.json"}}},
+            }
         )
         + "\n",
         encoding="utf-8",
@@ -414,6 +418,7 @@ def test_is_checkpoint_ready_for_request_requires_mmu_sidecars_when_tlb_present(
             str(tmp_path),
             "snapshot_0",
             "moesi_cmp_directory",
+            runtime_llc_slice_count=8,
             core_count=8,
             memory_gb=32,
             kernel="/tmp/kernel",
@@ -436,6 +441,7 @@ def test_is_checkpoint_ready_for_request_requires_mmu_sidecars_when_tlb_present(
             str(tmp_path),
             "snapshot_0",
             "moesi_cmp_directory",
+            runtime_llc_slice_count=8,
             core_count=8,
             memory_gb=32,
             kernel="/tmp/kernel",
@@ -446,6 +452,63 @@ def test_is_checkpoint_ready_for_request_requires_mmu_sidecars_when_tlb_present(
             have_large_asid_64=True,
         )
         is True
+    )
+
+
+def test_is_checkpoint_ready_for_request_requires_matching_llc_slice_count(
+    tmp_path: Path,
+):
+    module = _load_qpoints_commands_module()
+
+    checkpoint_dir = tmp_path / "snapshot_0"
+    protocol_dir = checkpoint_dir / "gem5_uarch" / "moesi_cmp_directory"
+    protocol_dir.mkdir(parents=True)
+    machine_config = {
+        "core_count": 8,
+        "memory_gb": 32,
+        "kernel": "/tmp/kernel",
+        "bootloader": "/tmp/boot.bin",
+        "root_device": "/dev/vda",
+        "itb_size": 64,
+        "dtb_size": 64,
+        "have_large_asid_64": True,
+    }
+    (checkpoint_dir / "machine_config.json").write_text(
+        __import__("json").dumps(machine_config) + "\n",
+        encoding="utf-8",
+    )
+    for relative in (
+        "m5.cpt",
+        "snapshot_0.img",
+        "system.physmem.store0.pmem",
+        "system.physmem.store1.pmem",
+        "register-info.json",
+        "dev.info",
+    ):
+        path = checkpoint_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+    (protocol_dir / "manifest.json").write_text(
+        __import__("json").dumps({"llc_slice_count": 1}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        module._is_checkpoint_ready_for_request(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+            runtime_llc_slice_count=8,
+            core_count=8,
+            memory_gb=32,
+            kernel="/tmp/kernel",
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            itb_size=64,
+            dtb_size=64,
+            have_large_asid_64=True,
+        )
+        is False
     )
 
 

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -512,6 +512,53 @@ def test_is_checkpoint_ready_for_request_requires_matching_llc_slice_count(
     )
 
 
+def test_is_checkpoint_ready_for_request_treats_corrupt_metadata_as_not_ready(
+    tmp_path: Path,
+):
+    module = _load_qpoints_commands_module()
+
+    checkpoint_dir = tmp_path / "snapshot_0"
+    protocol_dir = checkpoint_dir / "gem5_uarch" / "moesi_cmp_directory"
+    protocol_dir.mkdir(parents=True)
+    (checkpoint_dir / "machine_config.json").write_text(
+        "{not-json\n",
+        encoding="utf-8",
+    )
+    for relative in (
+        "m5.cpt",
+        "snapshot_0.img",
+        "system.physmem.store0.pmem",
+        "system.physmem.store1.pmem",
+        "register-info.json",
+        "dev.info",
+        "gem5_uarch/moesi_cmp_directory/manifest.json",
+    ):
+        path = checkpoint_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.name == "manifest.json":
+            path.write_text("{also-not-json\n", encoding="utf-8")
+        else:
+            path.write_text("{}\n", encoding="utf-8")
+
+    assert (
+        module._is_checkpoint_ready_for_request(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+            runtime_llc_slice_count=8,
+            core_count=8,
+            memory_gb=32,
+            kernel="/tmp/kernel",
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            itb_size=64,
+            dtb_size=64,
+            have_large_asid_64=True,
+        )
+        is False
+    )
+
+
 def test_run_sample_converts_each_snapshot_before_running_gem5():
     module = _load_qpoints_commands_module()
 

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -233,6 +233,283 @@ def test_prepare_snapshot_gem5_uarch_skips_when_qflex_uarch_missing(capsys):
     assert "skipping gem5 uarch preparation" in capsys.readouterr().out
 
 
+def test_is_gem_bundle_ready_requires_expected_files(tmp_path: Path):
+    module = _load_qpoints_commands_module()
+
+    run_dir = tmp_path / "run"
+    gem_dir = run_dir / "snapshot_0.gem"
+    gem_dir.mkdir(parents=True)
+
+    assert module._is_gem_bundle_ready(run_dir, "snapshot_0") is False
+
+    (gem_dir / "register-info.json").write_text("{}\n", encoding="utf-8")
+    (gem_dir / "dev.info").write_text("dev\n", encoding="utf-8")
+    (gem_dir / "system.physmem.store1.pmem").write_bytes(b"x")
+
+    assert module._is_gem_bundle_ready(run_dir, "snapshot_0") is True
+
+
+def test_is_checkpoint_ready_requires_protocol_manifest(tmp_path: Path):
+    module = _load_qpoints_commands_module()
+
+    checkpoint_dir = tmp_path / "snapshot_0"
+    (checkpoint_dir / "gem5_uarch" / "moesi_cmp_directory").mkdir(parents=True)
+    for relative in (
+        "machine_config.json",
+        "m5.cpt",
+        "snapshot_0.img",
+        "system.physmem.store0.pmem",
+        "system.physmem.store1.pmem",
+        "register-info.json",
+        "dev.info",
+        "gem5_uarch/moesi_cmp_directory/manifest.json",
+    ):
+        path = checkpoint_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x\n", encoding="utf-8")
+
+    assert (
+        module._is_checkpoint_ready(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+        )
+        is True
+    )
+    assert (
+        module._is_checkpoint_ready(
+            str(tmp_path),
+            "snapshot_0",
+            "mesi_two_level",
+        )
+        is False
+    )
+
+
+def test_cleanup_snapshot_gem5_artifacts_removes_only_derived_outputs(tmp_path: Path):
+    module = _load_qpoints_commands_module()
+
+    qflex_root = tmp_path / "experiment"
+    gem5_root = tmp_path / "checkpoints"
+    gem_dir = qflex_root / "run" / "snapshot_0.gem"
+    checkpoint_dir = gem5_root / "snapshot_0"
+    source_uarch = qflex_root / "run" / "snapshot_0.uarch"
+    source_loc = qflex_root / "run" / "snapshot_0.loc"
+    source_state = qflex_root / "run" / "snapshot_0.state.zstd"
+
+    gem_dir.mkdir(parents=True)
+    checkpoint_dir.mkdir(parents=True)
+    source_uarch.mkdir(parents=True)
+    source_loc.write_text("loc\n", encoding="utf-8")
+    source_state.write_text("state\n", encoding="utf-8")
+
+    module._cleanup_snapshot_gem5_artifacts(
+        qflex_ckp_dir=str(qflex_root),
+        gem5_ckp_dir=str(gem5_root),
+        snapshot="snapshot_0",
+    )
+
+    assert not gem_dir.exists()
+    assert not checkpoint_dir.exists()
+    assert source_uarch.exists()
+    assert source_loc.exists()
+    assert source_state.exists()
+
+
+def test_is_checkpoint_ready_for_request_rejects_machine_contract_mismatch(
+    tmp_path: Path,
+):
+    module = _load_qpoints_commands_module()
+
+    checkpoint_dir = tmp_path / "snapshot_0"
+    (checkpoint_dir / "gem5_uarch" / "moesi_cmp_directory").mkdir(parents=True)
+    machine_config = {
+        "core_count": 4,
+        "memory_gb": 32,
+        "kernel": "/tmp/kernel",
+        "bootloader": "/tmp/boot.bin",
+        "root_device": "/dev/vda",
+        "itb_size": 64,
+        "dtb_size": 64,
+        "have_large_asid_64": True,
+    }
+    (checkpoint_dir / "machine_config.json").write_text(
+        __import__("json").dumps(machine_config) + "\n",
+        encoding="utf-8",
+    )
+    for relative in (
+        "m5.cpt",
+        "snapshot_0.img",
+        "system.physmem.store0.pmem",
+        "system.physmem.store1.pmem",
+        "register-info.json",
+        "dev.info",
+        "gem5_uarch/moesi_cmp_directory/manifest.json",
+    ):
+        path = checkpoint_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+
+    assert (
+        module._is_checkpoint_ready_for_request(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+            core_count=8,
+            memory_gb=32,
+            kernel="/tmp/kernel",
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            itb_size=64,
+            dtb_size=64,
+            have_large_asid_64=True,
+        )
+        is False
+    )
+
+
+def test_is_checkpoint_ready_for_request_requires_mmu_sidecars_when_tlb_present(
+    tmp_path: Path,
+):
+    module = _load_qpoints_commands_module()
+
+    checkpoint_dir = tmp_path / "snapshot_0"
+    protocol_dir = checkpoint_dir / "gem5_uarch" / "moesi_cmp_directory"
+    protocol_dir.mkdir(parents=True)
+    machine_config = {
+        "core_count": 8,
+        "memory_gb": 32,
+        "kernel": "/tmp/kernel",
+        "bootloader": "/tmp/boot.bin",
+        "root_device": "/dev/vda",
+        "itb_size": 64,
+        "dtb_size": 64,
+        "have_large_asid_64": True,
+    }
+    (checkpoint_dir / "machine_config.json").write_text(
+        __import__("json").dumps(machine_config) + "\n",
+        encoding="utf-8",
+    )
+    for relative in (
+        "m5.cpt",
+        "snapshot_0.img",
+        "system.physmem.store0.pmem",
+        "system.physmem.store1.pmem",
+        "register-info.json",
+        "dev.info",
+    ):
+        path = checkpoint_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+    (protocol_dir / "manifest.json").write_text(
+        __import__("json").dumps(
+            {"components": {"tlb": {"source_files": {"0": "cpu0.json"}}}}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        module._is_checkpoint_ready_for_request(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+            core_count=8,
+            memory_gb=32,
+            kernel="/tmp/kernel",
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            itb_size=64,
+            dtb_size=64,
+            have_large_asid_64=True,
+        )
+        is False
+    )
+
+    (checkpoint_dir / "gem5_uarch" / "mmu-cpu0.cpt").write_text(
+        "mmu\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        module._is_checkpoint_ready_for_request(
+            str(tmp_path),
+            "snapshot_0",
+            "moesi_cmp_directory",
+            core_count=8,
+            memory_gb=32,
+            kernel="/tmp/kernel",
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            itb_size=64,
+            dtb_size=64,
+            have_large_asid_64=True,
+        )
+        is True
+    )
+
+
+def test_run_sample_converts_each_snapshot_before_running_gem5():
+    module = _load_qpoints_commands_module()
+
+    with mock.patch.object(
+        module, "convert_single"
+    ) as convert_mock, mock.patch.object(
+        module, "run_gem5"
+    ) as run_gem5_mock, mock.patch.object(
+        module, "_cleanup_snapshot_gem5_artifacts"
+    ) as cleanup_mock, mock.patch.object(
+        module, "_load_uipc_summary",
+        side_effect=[
+            {"engine": "gem5", "cores": [{"core": 0, "ipc": 1.0, "uipc": 1.0}], "aggregate": {"ipc": 1.0, "uipc": 1.0}},
+            {"engine": "gem5", "cores": [{"core": 0, "ipc": 2.0, "uipc": 2.0}], "aggregate": {"ipc": 2.0, "uipc": 2.0}},
+        ],
+    ), mock.patch.object(
+        module, "_write_uipc_report", return_value=Path("/tmp/uipc_report.json")
+    ) as write_report_mock:
+        report = module.run_sample(
+            qflex_ckp_dir="/tmp/experiment",
+            gem5_ckp_dir="/tmp/checkpoints/exp",
+            experiment="exp",
+            base="/tmp/experiment/root.qcow2",
+            first="snapshot_0",
+            last="snapshot_1",
+            core_count=8,
+            memory_gb=32,
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            warmup_cycles=200000,
+            measurement_cycles=1000000,
+            timing_ruby=False,
+            timing_ruby_moesi=True,
+            cache_hierarchy_restore=True,
+            sim_config="/tmp/moesi.args",
+        )
+
+    assert report == Path("/tmp/uipc_report.json")
+    assert [call.kwargs["snapshot"] for call in convert_mock.call_args_list] == [
+        "snapshot_0",
+        "snapshot_1",
+    ]
+    assert [call.kwargs["snapshot"] for call in run_gem5_mock.call_args_list] == [
+        "snapshot_0",
+        "snapshot_1",
+    ]
+    assert [call.kwargs["snapshot"] for call in cleanup_mock.call_args_list] == [
+        "snapshot_0",
+        "snapshot_1",
+    ]
+    for call in convert_mock.call_args_list:
+        assert call.kwargs["qflex_ckp_dir"] == "/tmp/experiment"
+        assert call.kwargs["base"] == "/tmp/experiment/root.qcow2"
+        assert call.kwargs["ruby_protocol"] == "moesi_cmp_directory"
+        assert call.kwargs["overwrite"] is False
+    for call in cleanup_mock.call_args_list:
+        assert call.kwargs["qflex_ckp_dir"] == "/tmp/experiment"
+        assert call.kwargs["gem5_ckp_dir"] == "/tmp/checkpoints/exp"
+    write_report_mock.assert_called_once()
+
+
 def test_prepare_snapshot_gem5_uarch_invokes_qpoints_postprocessor(tmp_path: Path):
     module = _load_qpoints_commands_module()
 

--- a/tests/test_qpoints_cli.py
+++ b/tests/test_qpoints_cli.py
@@ -484,6 +484,7 @@ def test_run_sample_converts_each_snapshot_before_running_gem5():
             timing_ruby_moesi=True,
             cache_hierarchy_restore=True,
             sim_config="/tmp/moesi.args",
+            cleanup_conversion_artifacts=True,
         )
 
     assert report == Path("/tmp/uipc_report.json")
@@ -508,6 +509,50 @@ def test_run_sample_converts_each_snapshot_before_running_gem5():
         assert call.kwargs["qflex_ckp_dir"] == "/tmp/experiment"
         assert call.kwargs["gem5_ckp_dir"] == "/tmp/checkpoints/exp"
     write_report_mock.assert_called_once()
+
+
+def test_run_sample_can_keep_conversion_artifacts():
+    module = _load_qpoints_commands_module()
+
+    with mock.patch.object(
+        module, "convert_single"
+    ) as convert_mock, mock.patch.object(
+        module, "run_gem5"
+    ) as run_gem5_mock, mock.patch.object(
+        module, "_cleanup_snapshot_gem5_artifacts"
+    ) as cleanup_mock, mock.patch.object(
+        module, "_load_uipc_summary",
+        return_value={
+            "engine": "gem5",
+            "cores": [{"core": 0, "ipc": 1.0, "uipc": 1.0}],
+            "aggregate": {"ipc": 1.0, "uipc": 1.0},
+        },
+    ), mock.patch.object(
+        module, "_write_uipc_report", return_value=Path("/tmp/uipc_report.json")
+    ):
+        module.run_sample(
+            qflex_ckp_dir="/tmp/experiment",
+            gem5_ckp_dir="/tmp/checkpoints/exp",
+            experiment="exp",
+            base="/tmp/experiment/root.qcow2",
+            first="snapshot_0",
+            last="snapshot_0",
+            core_count=8,
+            memory_gb=32,
+            bootloader="/tmp/boot.bin",
+            root_device="/dev/vda",
+            warmup_cycles=200000,
+            measurement_cycles=1000000,
+            timing_ruby=False,
+            timing_ruby_moesi=True,
+            cache_hierarchy_restore=True,
+            sim_config="/tmp/moesi.args",
+            cleanup_conversion_artifacts=False,
+        )
+
+    convert_mock.assert_called_once()
+    run_gem5_mock.assert_called_once()
+    cleanup_mock.assert_not_called()
 
 
 def test_prepare_snapshot_gem5_uarch_invokes_qpoints_postprocessor(tmp_path: Path):


### PR DESCRIPTION
## Summary
- make gem5 run_sample orchestrate convert_single before each snapshot run
- add strong conversion readiness checks and optional cleanup control
- clean up derived gem5 artifacts after successful per-snapshot runs when enabled
- update QPoints to the multi-snapshot validation record commit

## Validation
- focused pytest coverage for readiness, orchestration, and cleanup behavior
- runtime gem5 run_sample over snapshot_0..snapshot_1 with lazy conversion and cleanup enabled

## Dependency
- depends on the QPoints PR from the same branch name ali/ws-multi-sample-run
