### PR TITLE
qflex: document kernel ELF recovery and update QPoints pointer

### DIFF
--- a/docs/gem5_conversion/alpine_kernel_elf_recovery.md
+++ b/docs/gem5_conversion/alpine_kernel_elf_recovery.md
@@ -1,0 +1,171 @@
+# Recovering an Alpine Kernel ELF with `vmlinux-to-elf`
+
+This document covers one scope only:
+
+- after `qflex boot`, if the boot workflow did not already capture a ready
+  `vmlinux` ELF, how to recover one from the kernel bundle produced by `boot`
+
+It is written for:
+
+- host: `iccluster118`
+- container: `cb8*`
+- repo: `/home/dev/qflex_git`
+
+## What `boot` is expected to leave behind
+
+The bounded `boot` workflow creates an experiment kernel bundle under:
+
+- `/mnt/sdb/aansari/experiments/<experiment>/kernel/`
+
+For an Alpine guest, that bundle is expected to contain at least:
+
+- `vmlinuz-*`
+- `System.map-*`
+- `config-*`
+
+Those files are the input to the recovery process below.
+
+This document does not cover:
+
+- rebuilding Alpine kernels from source
+- using `aports`
+- validating a recovered ELF against a timing checkpoint
+
+## Toolchain prerequisites
+
+The recovery process runs on the host and needs:
+
+- `git`
+- `python3`
+- `python3 -m venv`
+- network access to clone `vmlinux-to-elf`
+- network access for `pip install .` to resolve Python dependencies
+
+## Inputs
+
+The minimum required input is:
+
+- the `vmlinuz-*` file from the kernel bundle produced by `boot`
+
+Useful companion files:
+
+- `System.map-*`
+- `config-*`
+
+For the current web-search example on this machine, the boot-step kernel bundle
+contains:
+
+- `/mnt/sdb/aansari/experiments/ws-image-fresh-8c/kernel/vmlinuz-virt`
+- `/mnt/sdb/aansari/experiments/ws-image-fresh-8c/kernel/System.map-virt`
+- `/mnt/sdb/aansari/experiments/ws-image-fresh-8c/kernel/config-virt`
+
+## Output
+
+The output is a recovered kernel ELF, for example:
+
+- `/tmp/qflex-kernel-recovery/vmlinux-recovered-from-vmlinuz.elf`
+
+## Step-by-step procedure
+
+### 1. Prepare a disposable host workspace
+
+```bash
+mkdir -p /tmp/qflex-kernel-recovery
+cd /tmp/qflex-kernel-recovery
+```
+
+### 2. Clone `vmlinux-to-elf`
+
+```bash
+git clone https://github.com/marin-m/vmlinux-to-elf.git /tmp/vmlinux-to-elf
+```
+
+### 3. Create a virtualenv and install the tool
+
+```bash
+cd /tmp/vmlinux-to-elf
+python3 -m venv .venv
+. .venv/bin/activate
+pip install --upgrade pip
+pip install .
+```
+
+Sanity check:
+
+```bash
+vmlinux-to-elf --help
+```
+
+### 4. Run the recovery on the `vmlinuz-*` captured by `boot`
+
+Example using the current web-search kernel bundle:
+
+```bash
+cd /tmp/vmlinux-to-elf
+. .venv/bin/activate
+
+vmlinux-to-elf \
+  /mnt/sdb/aansari/experiments/ws-image-fresh-8c/kernel/vmlinuz-virt \
+  /tmp/qflex-kernel-recovery/vmlinux-recovered-from-vmlinuz.elf
+```
+
+For another experiment, replace the input path with the `vmlinuz-*` file from:
+
+- `/mnt/sdb/aansari/experiments/<experiment>/kernel/`
+
+What the tool should report:
+
+- successful decompression of the compressed kernel image
+- detection of the kernel release string
+- detection of `aarch64`
+- successful writing of the output ELF
+
+## Basic verification
+
+Check the recovered file type:
+
+```bash
+file /tmp/qflex-kernel-recovery/vmlinux-recovered-from-vmlinuz.elf
+```
+
+Expected shape:
+
+- `ELF 64-bit`
+- `ARM aarch64`
+- `statically linked`
+
+Check the embedded release string:
+
+```bash
+strings /tmp/qflex-kernel-recovery/vmlinux-recovered-from-vmlinuz.elf \
+  | grep -m 1 'Linux version'
+```
+
+For the current web-search example on this machine, the expected version string
+starts with:
+
+```text
+Linux version 6.1.34-3-virt ...
+```
+
+## Example: store the recovered ELF next to the image
+
+If you accept the recovered ELF as the reference kernel for an image, store it
+next to that image. For the current web-search image:
+
+```bash
+cp /tmp/qflex-kernel-recovery/vmlinux-recovered-from-vmlinuz.elf \
+  /mnt/sdb/aansari/ws-image/web-search-fresh-8c/vmlinux-6.1.34-3-virt.elf
+```
+
+## Summary
+
+For an Alpine guest in this project:
+
+1. run `qflex boot`
+2. go to the kernel bundle produced by `boot`
+3. take the captured `vmlinuz-*`
+4. recover an ELF with `vmlinux-to-elf`
+5. verify the architecture and release string
+
+That is the documented extraction process.

--- a/docs/gem5_conversion/web_search_fresh_8c_runbook.md
+++ b/docs/gem5_conversion/web_search_fresh_8c_runbook.md
@@ -1,0 +1,290 @@
+# Web-Search Fresh 8C Runbook
+
+This is a machine-specific walkthrough for running the existing web-search
+image on this machine with the `qflex` CLI from `boot` through `run_sample`.
+
+This is not a general CLI document. It is customized for:
+
+- host: `iccluster118`
+- container: `cb8*`
+- repo: `/home/dev/qflex_git`
+- args file: `/home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args`
+- comparison args file:
+  `/home/dev/qflex_git/args/ws_image_fresh_8c_flexus_compare.qflex.args`
+- image folder: `/mnt/sdb/aansari/ws-image/web-search-fresh-8c`
+- experiment folder: `/mnt/sdb/aansari/experiments/ws-image-fresh-8c`
+- checkpoint folder: `/mnt/sdb/aansari/checkpoints/ws-image-fresh-8c`
+- image file: `root.qcow2`
+- reference kernel folder:
+  `/mnt/sdb/aansari/ws-image/web-search-fresh-8c`
+- reference kernel ELF:
+  `/mnt/sdb/aansari/ws-image/web-search-fresh-8c/vmlinux-6.1.34-3-virt.elf`
+
+All commands below assume:
+
+```bash
+cd /home/dev/qflex_git
+```
+
+## 1. Boot the image and create the `boot` snapshot
+
+This is the bounded `boot` flow. It boots the VM, captures kernel provenance,
+creates the `boot` snapshot, and shuts the VM down.
+
+```bash
+./qflex boot --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args
+```
+
+Expected result:
+
+- internal QEMU snapshot `boot`
+- experiment folder created under:
+  `/mnt/sdb/aansari/experiments/ws-image-fresh-8c`
+
+## 2. If `boot` ends with manual kernel action, adopt the reference kernel ELF
+
+The bounded `boot` workflow can end with a kernel status that requires manual
+user action if the matching guest-side `vmlinux` ELF is not found automatically.
+
+For this machine and this web-search image, the reference kernel ELF now lives
+next to the qcow2 image here:
+
+- `/mnt/sdb/aansari/ws-image/web-search-fresh-8c`
+
+Use that reference ELF to mark the experiment kernel bundle ready:
+
+```bash
+./qflex kernel adopt \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --kernel /mnt/sdb/aansari/ws-image/web-search-fresh-8c/vmlinux-6.1.34-3-virt.elf
+```
+
+Use this step only when `boot` reports that manual kernel capture/adoption is
+required. If `boot` already leaves the kernel status in `ready`, skip this
+step.
+
+## 3. Load the `boot` snapshot and drive the workload to the desired state
+
+This starts a live QEMU session from `boot`.
+
+```bash
+./qflex load \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --loadvm-name boot
+```
+
+Inside that live session, drive the web-search workload to the state you want
+to use as the baseline for initialization.
+
+When you are ready, create a new internal snapshot named `loaded` from the QEMU
+monitor and then quit the VM:
+
+```text
+savevm loaded
+quit
+```
+
+This runbook uses `loaded` as the post-load baseline snapshot name.
+
+## 4. Initialize long-history state and create `init_warmed`
+
+This stage warms the long-history BXKraken-side state and creates the
+`init_warmed` snapshot. BBL-BTB collection is enabled so the later gem5
+lineage keeps frontend export continuity.
+
+```bash
+./qflex initialize \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --loadvm-name loaded \
+  --collect-gem5-bbl-btb
+```
+
+Expected result:
+
+- internal QEMU snapshot `init_warmed`
+
+## 5. Run functional warming and generate the snapshot lineage
+
+This stage resumes from `init_warmed` and drops the sampled snapshots.
+
+The command below uses:
+
+- `--sample-size 100` to create `snapshot_0` through `snapshot_99`
+- `--collect-gem5-bbl-btb` to continue the BBL-BTB export lineage
+
+This runbook intentionally does **not** use `--emit-gem` during `fw`.
+Instead, the `.gem` bundle is created lazily during `run_sample` and then
+cleaned up after each successful gem5 run. This keeps the functional-warming
+phase lighter and avoids storing a full `.gem` tree for every snapshot when the
+timing phase can regenerate the derived gem5 artifacts on demand.
+
+```bash
+./qflex fw \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --loadvm-name init_warmed \
+  --sample-size 100 \
+  --collect-gem5-bbl-btb
+```
+
+Expected result:
+
+- internal QEMU snapshots:
+  - `snapshot_0`
+  - `snapshot_1`
+  - ...
+  - `snapshot_99`
+- run-directory artifacts under:
+  `/mnt/sdb/aansari/experiments/ws-image-fresh-8c/run/`
+
+If you want a different lineage length, change `--sample-size` and adjust the
+`run_sample` range accordingly.
+
+## 6. Run the full snapshot range with Flexus
+
+This runs the entire generated lineage from the first snapshot to the last
+snapshot using the Flexus timing engine.
+
+```bash
+./qflex run_sample \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c_flexus_compare.qflex.args \
+  --first snapshot_0 \
+  --last snapshot_99 \
+  --warmup-cycles 200000 \
+  --measurement-cycles 1000000 \
+  --timing-engine flexus
+```
+
+Results are written under:
+
+- `/home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c/`
+
+Important files:
+
+- `uipc_report.json`
+- `snapshot_N/uipc_summary.json`
+- `snapshot_N/all.measurement.end.log`
+
+## 7. Run the full snapshot range with gem5
+
+This runs the same snapshot range with the gem5 MOESI timing path.
+
+This path uses lazy conversion by default:
+
+- if `snapshot_N.gem/` and the converted gem5 checkpoint do not already exist,
+  `run_sample` creates them for the current snapshot
+- after a successful run, the default cleanup behavior removes those derived
+  gem5 conversion artifacts again
+
+That is why the `fw` step above does not emit `.gem` bundles up front.
+
+```bash
+./qflex run_sample \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c_flexus_compare.qflex.args \
+  --first snapshot_0 \
+  --last snapshot_99 \
+  --warmup-cycles 200000 \
+  --measurement-cycles 1000000 \
+  --timing-engine gem5 \
+  --timing-ruby-moesi \
+  --sim-config /home/dev/qflex_git/QPoints/configs/timing_ruby_moesi_ws_flexus_mesh_ref_8c.args
+```
+
+Results are written under:
+
+- `/home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c/`
+
+Important files:
+
+- `uipc_report.json`
+- `snapshot_N/uipc_summary.json`
+- `snapshot_N/stats.txt`
+
+## 8. Preserve Flexus and gem5 outputs separately
+
+Both timing engines currently write canonical reports under the same top-level
+folder:
+
+- `/home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c/`
+
+So if you run both engines back to back, the second run will overwrite the
+first run's report tree.
+
+Use this sequence instead:
+
+1. run one timing engine
+2. rename its result folder immediately
+3. run the second timing engine
+4. rename its result folder immediately
+
+For example, if you run Flexus first:
+
+```bash
+mv /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c \
+   /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c_flexus_200k_1m
+```
+
+Then after the gem5 run:
+
+```bash
+mv /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c \
+   /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c_gem5_200k_1m
+```
+
+At the end, the preserved result folders are:
+
+- `/home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c_flexus_200k_1m`
+- `/home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c_gem5_200k_1m`
+
+## 9. Minimal command list
+
+If you only want the command sequence without the surrounding notes, it is:
+
+```bash
+cd /home/dev/qflex_git
+
+./qflex boot \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args
+
+./qflex kernel adopt \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --kernel /mnt/sdb/aansari/ws-image/web-search-fresh-8c/vmlinux-6.1.34-3-virt.elf
+
+./qflex load \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --loadvm-name boot
+
+./qflex initialize \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --loadvm-name loaded \
+  --collect-gem5-bbl-btb
+
+./qflex fw \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c.qflex.args \
+  --loadvm-name init_warmed \
+  --sample-size 100 \
+  --collect-gem5-bbl-btb
+
+./qflex run_sample \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c_flexus_compare.qflex.args \
+  --first snapshot_0 \
+  --last snapshot_99 \
+  --warmup-cycles 200000 \
+  --measurement-cycles 1000000 \
+  --timing-engine flexus
+
+mv /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c \
+   /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c_flexus_200k_1m
+
+./qflex run_sample \
+  --args-file /home/dev/qflex_git/args/ws_image_fresh_8c_flexus_compare.qflex.args \
+  --first snapshot_0 \
+  --last snapshot_99 \
+  --warmup-cycles 200000 \
+  --measurement-cycles 1000000 \
+  --timing-engine gem5 \
+  --timing-ruby-moesi \
+  --sim-config /home/dev/qflex_git/QPoints/configs/timing_ruby_moesi_ws_flexus_mesh_ref_8c.args
+
+mv /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c \
+   /home/dev/qflex_git/QPoints/sim_outs/ws-image-fresh-8c_gem5_200k_1m
+```


### PR DESCRIPTION
## Summary
- add the Alpine kernel ELF recovery document for the host-side vmlinux-to-elf workflow
- update the web-search runbook to use the new image-adjacent kernel reference path and the current lazy .gem flow
- refresh the QPoints submodule pointer after merging the kernel-ELF trust record

## Validation
- verified the runbook against the current machine args, boot snapshot naming, and recorded web-search commands
- QPoints PR #32 is already merged and this branch updates the submodule pointer to that canonical commit
